### PR TITLE
Fix #31 - Multiple levels of generic type parameters doesn't work

### DIFF
--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DataLibraryJson.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DataLibraryJson.java
@@ -2,10 +2,10 @@
 package cz.habarta.typescript.generator;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+
 import java.util.List;
 
 public class DataLibraryJson {
-
     public List<ClassMapping> classMappings;
     public List<TypeAlias> typeAliases;
 
@@ -25,8 +25,7 @@ public class DataLibraryJson {
         List("list"),
         Map("map"),
         Optional("optional"),
-        Wrapper("wrapper"),
-        ;
+        Wrapper("wrapper");
 
         private final String name;
 
@@ -38,12 +37,10 @@ public class DataLibraryJson {
         public String getName() {
             return name;
         }
-
     }
 
     public static class TypeAlias {
         public String name;
         public String definition;
     }
-
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/DefaultTypeProcessor.java
@@ -6,13 +6,13 @@ import cz.habarta.typescript.generator.type.JTypeWithNullability;
 import cz.habarta.typescript.generator.type.JUnionType;
 import cz.habarta.typescript.generator.util.GenericsResolver;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.lang.reflect.*;
 import java.time.temporal.Temporal;
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class DefaultTypeProcessor implements TypeProcessor {
-
     private final LoadedDataLibraries known;
 
     public DefaultTypeProcessor() {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ExcludingTypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ExcludingTypeProcessor.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator;
 
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -10,7 +11,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 public class ExcludingTypeProcessor implements TypeProcessor {
-
     private final Predicate<String> excludeFilter;
 
     public ExcludingTypeProcessor(List<String> excludedTypes) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Input.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Input.java
@@ -5,6 +5,7 @@ import cz.habarta.typescript.generator.parser.SourceType;
 import cz.habarta.typescript.generator.util.Utils;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
+
 import java.lang.reflect.Type;
 import java.net.URLClassLoader;
 import java.util.*;
@@ -13,7 +14,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class Input {
-
     private final List<SourceType<Type>> sourceTypes;
 
     private Input(List<SourceType<Type>> sourceTypes) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Jackson2ConfigurationResolved.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Jackson2ConfigurationResolved.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 public class Jackson2ConfigurationResolved {
-
     public JsonAutoDetect.Visibility fieldVisibility;
     public JsonAutoDetect.Visibility getterVisibility;
     public JsonAutoDetect.Visibility isGetterVisibility;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JaxrsApplicationScanner.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/JaxrsApplicationScanner.java
@@ -4,6 +4,7 @@ package cz.habarta.typescript.generator;
 import cz.habarta.typescript.generator.parser.SourceType;
 import cz.habarta.typescript.generator.util.Utils;
 import io.github.classgraph.ScanResult;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -13,9 +14,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 public class JaxrsApplicationScanner {
-
-    public static List<SourceType<Type>> scanJaxrsApplication(Class<?> jaxrsApplicationClass,
-            Predicate<String> isClassNameExcluded) {
+    public static List<SourceType<Type>> scanJaxrsApplication(Class<?> jaxrsApplicationClass, Predicate<String> isClassNameExcluded) {
         final ClassLoader originalContextClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(jaxrsApplicationClass.getClassLoader());

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/LoadedDataLibraries.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/LoadedDataLibraries.java
@@ -6,7 +6,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class LoadedDataLibraries {
-
     public final List<Class<?>> stringClasses;
     public final List<Class<?>> numberClasses;
     public final List<Class<?>> booleanClasses;
@@ -21,8 +20,7 @@ public class LoadedDataLibraries {
     public final List<Settings.CustomTypeAlias> typeAliases;
 
     public LoadedDataLibraries() {
-        this(empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(),
-                empty());
+        this(empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty(), empty());
     }
 
     private static <T> List<T> empty() {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/LoadedModuleDependencies.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/LoadedModuleDependencies.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.habarta.typescript.generator.emitter.InfoJson;
 import cz.habarta.typescript.generator.util.Pair;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -13,7 +14,6 @@ import java.util.Objects;
 import java.util.function.Function;
 
 public class LoadedModuleDependencies {
-
     private final Map<String/*javaClass*/, Pair<ModuleDependency, String/*namespacedName*/>> classMappings = new LinkedHashMap<>();
 
     public LoadedModuleDependencies(Settings settings, List<ModuleDependency> dependencies) {
@@ -46,10 +46,8 @@ public class LoadedModuleDependencies {
                 }
                 Objects.requireNonNull(dependency.infoJson, () -> reportNullParameter.apply("infoJson"));
                 if (settings.generateNpmPackageJson) {
-                    Objects.requireNonNull(dependency.npmPackageName,
-                            () -> reportNullParameter.apply("npmPackageName"));
-                    Objects.requireNonNull(dependency.npmVersionRange,
-                            () -> reportNullParameter.apply("npmVersionRange"));
+                    Objects.requireNonNull(dependency.npmPackageName, () -> reportNullParameter.apply("npmPackageName"));
+                    Objects.requireNonNull(dependency.npmVersionRange, () -> reportNullParameter.apply("npmVersionRange"));
                 } else {
                     if (dependency.npmPackageName != null) {
                         throw new RuntimeException(String.format(

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Logger.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Logger.java
@@ -2,7 +2,6 @@
 package cz.habarta.typescript.generator;
 
 public class Logger {
-
     private final Level level;
 
     public enum Level {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ModuleDependency.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ModuleDependency.java
@@ -3,11 +3,11 @@ package cz.habarta.typescript.generator;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.io.File;
 
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class ModuleDependency {
-
     public boolean global;
     public String importFrom;
     public String importAs;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Output.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/Output.java
@@ -5,7 +5,6 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 
 public class Output {
-
     private final Writer writer;
     private final String name;
     private final boolean closeWriter;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/RestNamespacing.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/RestNamespacing.java
@@ -2,7 +2,6 @@
 package cz.habarta.typescript.generator;
 
 public enum RestNamespacing {
-
     singleObject, perResource, byAnnotation
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/StringQuotes.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/StringQuotes.java
@@ -2,7 +2,6 @@
 package cz.habarta.typescript.generator;
 
 public enum StringQuotes {
-
     doubleQuotes, singleQuotes
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsParameter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsParameter.java
@@ -2,7 +2,6 @@
 package cz.habarta.typescript.generator;
 
 public class TsParameter {
-
     public final String name;
     public final TsType tsType;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsProperty.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsProperty.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator;
 import cz.habarta.typescript.generator.emitter.Emitter;
 
 public class TsProperty {
-
     public final String name;
     public final TsType tsType;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TsType.java
@@ -5,6 +5,7 @@ import cz.habarta.typescript.generator.compiler.Symbol;
 import cz.habarta.typescript.generator.emitter.Emittable;
 import cz.habarta.typescript.generator.emitter.Emitter;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -17,7 +18,6 @@ import java.util.stream.Stream;
  * That means something which can appear in type position (after ":" character).
  */
 public abstract class TsType implements Emittable {
-
     public static final TsType Any = new BasicType("any");
     public static final TsType Boolean = new BasicType("boolean");
     public static final TsType Number = new BasicType("number");

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeProcessor.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeProcessor.java
@@ -3,6 +3,7 @@ package cz.habarta.typescript.generator;
 
 import cz.habarta.typescript.generator.compiler.Symbol;
 import cz.habarta.typescript.generator.compiler.SymbolTable;
+
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,7 +11,6 @@ import java.util.List;
 import java.util.Objects;
 
 public interface TypeProcessor {
-
     /**
      * @return <code>null</code> if this processor didn't process passed java type
      */
@@ -31,7 +31,6 @@ public interface TypeProcessor {
     }
 
     class Context {
-
         private final SymbolTable symbolTable;
         private final TypeProcessor typeProcessor;
         private final Object typeContext;
@@ -41,8 +40,7 @@ public interface TypeProcessor {
             this(symbolTable, typeProcessor, typeContext, false);
         }
 
-        public Context(SymbolTable symbolTable, TypeProcessor typeProcessor, Object typeContext,
-                boolean insideCollection) {
+        public Context(SymbolTable symbolTable, TypeProcessor typeProcessor, Object typeContext, boolean insideCollection) {
             this.symbolTable = Objects.requireNonNull(symbolTable, "symbolTable");
             this.typeProcessor = Objects.requireNonNull(typeProcessor, "typeProcessor");
             this.typeContext = typeContext;
@@ -84,7 +82,6 @@ public interface TypeProcessor {
     }
 
     class Result {
-
         private final TsType tsType;
         private final List<Class<?>> discoveredClasses;
 
@@ -109,7 +106,6 @@ public interface TypeProcessor {
     }
 
     class Chain implements TypeProcessor {
-
         private final List<TypeProcessor> processors;
 
         public Chain(List<TypeProcessor> processors) {
@@ -128,9 +124,8 @@ public interface TypeProcessor {
                     return result;
                 }
             }
+
             return null;
         }
-
     }
-
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptFileType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptFileType.java
@@ -2,7 +2,5 @@
 package cz.habarta.typescript.generator;
 
 public enum TypeScriptFileType {
-
     declarationFile, implementationFile
-
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptGenerator.java
@@ -5,6 +5,7 @@ import cz.habarta.typescript.generator.compiler.ModelCompiler;
 import cz.habarta.typescript.generator.emitter.*;
 import cz.habarta.typescript.generator.parser.*;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.io.File;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -14,7 +15,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class TypeScriptGenerator {
-
     public static final String Version = getVersion();
 
     private static Logger logger = new Logger();

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptOutputKind.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/TypeScriptOutputKind.java
@@ -2,7 +2,5 @@
 package cz.habarta.typescript.generator;
 
 public enum TypeScriptOutputKind {
-
     global, module, ambientModule
-
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/ModelCompiler.java
@@ -1,4 +1,3 @@
-
 package cz.habarta.typescript.generator.compiler;
 
 import cz.habarta.typescript.generator.*;
@@ -8,6 +7,7 @@ import cz.habarta.typescript.generator.type.JTypeWithNullability;
 import cz.habarta.typescript.generator.util.GenericsResolver;
 import cz.habarta.typescript.generator.util.Pair;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -1356,7 +1356,7 @@ public class ModelCompiler {
     }
 
     private static boolean isValidIdentifierPart(char c) {
-        return Character.isUnicodeIdentifierPart(c) || c == '$' || c == '_' || c == '\u200C' || c == '\u200D';
+        return Character.isUnicodeIdentifierPart(c) ||  c == '.' ||  c == '<' ||  c == '>' || c == '$' || c == '_' || c == '\u200C' || c == '\u200D';
     }
 
 }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/SymbolTable.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/compiler/SymbolTable.java
@@ -5,14 +5,15 @@ import com.oracle.truffle.js.scriptengine.GraalJSScriptEngine;
 import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TypeScriptGenerator;
 import cz.habarta.typescript.generator.util.Pair;
-import java.util.*;
-import java.util.regex.Pattern;
-import javax.script.Invocable;
-import javax.script.ScriptEngine;
-import javax.script.ScriptException;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.HostAccess;
+
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * Name table.
@@ -114,8 +115,8 @@ public class SymbolTable {
     private void setSymbolQualifiedName(Symbol symbol, Class<?> cls, String suffix) {
         final String module;
         final String namespacedName;
-        final Pair<String/*module*/, String/*namespacedName*/> fullNameFromDependency = settings.getModuleDependencies()
-                .getFullName(cls);
+        // Pair<module, namespacedName>
+        final Pair<String, String> fullNameFromDependency = settings.getModuleDependencies().getFullName(cls);
         if (fullNameFromDependency != null) {
             module = fullNameFromDependency.getValue1();
             namespacedName = fullNameFromDependency.getValue2();
@@ -182,19 +183,20 @@ public class SymbolTable {
 
     // https://github.com/Microsoft/TypeScript/blob/master/doc/spec-ARCHIVED.md#221-reserved-words
     private static final Set<String> Keywords = new LinkedHashSet<>(Arrays.asList(
-            "break", "case", "catch", "class",
-            "const", "continue", "debugger", "default",
-            "delete", "do", "else", "enum",
-            "export", "extends", "false", "finally",
-            "for", "function", "if", "import",
-            "in", "instanceof", "new", "null",
-            "return", "super", "switch", "this",
-            "throw", "true", "try", "typeof",
-            "var", "void", "while", "with",
+        "break",             "case",              "catch",             "class",
+        "const",             "continue",          "debugger",          "default",
+        "delete",            "do",                "else",              "enum",
+        "export",            "extends",           "false",             "finally",
+        "for",               "function",          "if",                "import",
+        "in",                "instanceof",        "new",               "null",
+        "return",            "super",             "switch",            "this",
+        "throw",             "true",              "try",               "typeof",
+        "var",               "void",              "while",             "with",
 
-            "implements", "interface", "let", "package",
-            "private", "protected", "public", "static",
-            "yield"));
+        "implements",        "interface",         "let",               "package",
+        "private",           "protected",         "public",            "static",
+        "yield"
+    ));
 
     public static boolean isReservedWord(String word) {
         return Keywords.contains(word);
@@ -222,8 +224,8 @@ public class SymbolTable {
     }
 
     public Symbol getSymbolIfImported(Class<?> cls) {
-        final Pair<String/*module*/, String/*namespacedName*/> fullNameFromDependency = settings.getModuleDependencies()
-                .getFullName(cls);
+        // Pair<module, namespaceName>
+        final Pair<String, String> fullNameFromDependency = settings.getModuleDependencies().getFullName(cls);
         if (fullNameFromDependency != null) {
             final Symbol symbol = new Symbol(null);
             symbol.setFullName(fullNameFromDependency.getValue1(), fullNameFromDependency.getValue2());
@@ -234,7 +236,6 @@ public class SymbolTable {
     }
 
     public static class NameConflictException extends RuntimeException {
-
         private static final long serialVersionUID = 1L;
 
         public NameConflictException() {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/Emitter.java
@@ -4,6 +4,7 @@ package cz.habarta.typescript.generator.emitter;
 import cz.habarta.typescript.generator.*;
 import cz.habarta.typescript.generator.compiler.EnumMemberModel;
 import cz.habarta.typescript.generator.compiler.ModelCompiler;
+
 import java.io.IOException;
 import java.io.Writer;
 import java.text.SimpleDateFormat;
@@ -14,7 +15,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class Emitter implements EmitterExtension.Writer {
-
     private final Settings settings;
     private Writer writer;
     private int indent;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsAliasModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsAliasModel.java
@@ -3,11 +3,11 @@ package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.TsType;
 import cz.habarta.typescript.generator.compiler.Symbol;
+
 import java.util.Collections;
 import java.util.List;
 
 public class TsAliasModel extends TsDeclarationModel {
-
     private final List<TsType.GenericVariableType> typeParameters;
     private final TsType definition;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBinaryExpression.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsBinaryExpression.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.emitter;
 import cz.habarta.typescript.generator.Settings;
 
 public class TsBinaryExpression extends TsExpression {
-
     private final TsExpression left;
     private final TsBinaryOperator operator;
     private final TsExpression right;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsCallExpression.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsCallExpression.java
@@ -3,12 +3,12 @@ package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TsType;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class TsCallExpression extends TsExpression {
-
     private final TsExpression expression;
     private final List<TsType> typeArguments;
     private final List<TsExpression> arguments;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsCallableModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsCallableModel.java
@@ -2,11 +2,11 @@
 package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.TsType;
+
 import java.util.Collections;
 import java.util.List;
 
 public class TsCallableModel {
-
     protected final String name;
     protected final TsModifierFlags modifiers;
     protected final List<TsType.GenericVariableType> typeParameters;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsConstructorModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsConstructorModel.java
@@ -4,9 +4,7 @@ package cz.habarta.typescript.generator.emitter;
 import java.util.List;
 
 public class TsConstructorModel extends TsCallableModel {
-
-    public TsConstructorModel(TsModifierFlags modifiers, List<TsParameterModel> parameters, List<TsStatement> body,
-            List<String> comments) {
+    public TsConstructorModel(TsModifierFlags modifiers, List<TsParameterModel> parameters, List<TsStatement> body, List<String> comments) {
         super("constructor", modifiers, null, parameters, null, body, comments);
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsModel.java
@@ -4,6 +4,7 @@ package cz.habarta.typescript.generator.emitter;
 import cz.habarta.typescript.generator.compiler.EnumKind;
 import cz.habarta.typescript.generator.compiler.Symbol;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -17,8 +18,7 @@ public class TsModel {
     private final List<TsHelper> helpers;
 
     public TsModel() {
-        this(new ArrayList<TsBeanModel>(), new ArrayList<TsEnumModel>(), new ArrayList<TsEnumModel>(),
-                new ArrayList<TsAliasModel>(), new ArrayList<TsHelper>());
+        this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
     }
 
     public TsModel(List<TsBeanModel> beans, List<TsEnumModel> enums, List<TsEnumModel> originalStringEnums,

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsPrefixUnaryExpression.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsPrefixUnaryExpression.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.emitter;
 import cz.habarta.typescript.generator.Settings;
 
 public class TsPrefixUnaryExpression extends TsExpression {
-
     private final TsUnaryOperator operator;
     private final TsExpression operand;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsPropertyModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsPropertyModel.java
@@ -4,10 +4,10 @@ package cz.habarta.typescript.generator.emitter;
 import cz.habarta.typescript.generator.TsProperty;
 import cz.habarta.typescript.generator.TsType;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.util.List;
 
 public class TsPropertyModel extends TsProperty implements Comparable<TsProperty> {
-
     public final List<TsDecorator> decorators;
     public final TsModifierFlags modifiers;
     public final boolean ownProperty; // property exists directly on the bean, should not be inherited

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsReturnStatement.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsReturnStatement.java
@@ -2,7 +2,6 @@
 package cz.habarta.typescript.generator.emitter;
 
 public class TsReturnStatement extends TsStatement {
-
     private final TsExpression expression;
 
     public TsReturnStatement() {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsStringLiteral.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsStringLiteral.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.emitter;
 import cz.habarta.typescript.generator.Settings;
 
 public class TsStringLiteral extends TsExpression {
-
     private final String literal;
 
     public TsStringLiteral(String literal) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsSuperExpression.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsSuperExpression.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.emitter;
 import cz.habarta.typescript.generator.Settings;
 
 public class TsSuperExpression extends TsExpression {
-
     @Override
     public String format(Settings settings) {
         return "super";

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsSwitchCaseClause.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsSwitchCaseClause.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.emitter;
 import java.util.List;
 
 public class TsSwitchCaseClause extends TsStatement {
-
     private final TsExpression expression;
     private final List<TsStatement> statements;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsSwitchStatement.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsSwitchStatement.java
@@ -2,10 +2,10 @@
 package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.util.List;
 
 public class TsSwitchStatement extends TsStatement {
-
     private final TsExpression expression;
     private final List<TsSwitchCaseClause> caseClauses;
     private final List<TsStatement> defaultClause;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsTaggedTemplateLiteral.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsTaggedTemplateLiteral.java
@@ -2,10 +2,10 @@
 package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.Settings;
+
 import java.util.List;
 
 public class TsTaggedTemplateLiteral extends TsTemplateLiteral {
-
     private final TsExpression tagFunction;
 
     public TsTaggedTemplateLiteral(TsExpression tagFunction, List<TsExpression/*|TsStringLiteral*/> spans) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsTemplateLiteral.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsTemplateLiteral.java
@@ -2,10 +2,10 @@
 package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.Settings;
+
 import java.util.List;
 
 public class TsTemplateLiteral extends TsExpression {
-
     private final List<TsExpression/*|TsStringLiteral*/> spans;
 
     public TsTemplateLiteral(List<TsExpression> spans) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsThisExpression.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsThisExpression.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.emitter;
 import cz.habarta.typescript.generator.Settings;
 
 public class TsThisExpression extends TsExpression {
-
     @Override
     public String format(Settings settings) {
         return "this";

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsTypeReferenceExpression.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsTypeReferenceExpression.java
@@ -5,7 +5,6 @@ import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TsType;
 
 public class TsTypeReferenceExpression extends TsExpression {
-
     private final TsType.ReferenceType type;
 
     public TsTypeReferenceExpression(TsType.ReferenceType type) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsUnaryOperator.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsUnaryOperator.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.emitter;
 import cz.habarta.typescript.generator.Settings;
 
 public enum TsUnaryOperator implements Emittable {
-
     Exclamation("!");
 
     private final String formatted;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsVariableDeclarationStatement.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/emitter/TsVariableDeclarationStatement.java
@@ -2,10 +2,10 @@
 package cz.habarta.typescript.generator.emitter;
 
 import cz.habarta.typescript.generator.TsType;
+
 import java.util.Objects;
 
 public class TsVariableDeclarationStatement extends TsStatement {
-
     private final boolean isConst;
     private final String name;
     private final TsType type;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/BeanPropertyPathExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/BeanPropertyPathExtension.java
@@ -3,6 +3,7 @@ package cz.habarta.typescript.generator.ext;
 import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TsType;
 import cz.habarta.typescript.generator.emitter.*;
+
 import java.util.*;
 
 /**
@@ -18,7 +19,6 @@ import java.util.*;
  * (in this case "field1.field2")
  */
 public class BeanPropertyPathExtension extends EmitterExtension {
-
     @Override
     public EmitterExtensionFeatures getFeatures() {
         final EmitterExtensionFeatures features = new EmitterExtensionFeatures();
@@ -75,7 +75,7 @@ public class BeanPropertyPathExtension extends EmitterExtension {
         final TsBeanModel parentBean = getBeanModelByType(model, bean.getParent());
         final Set<TsBeanModel> emittedBeans = parentBean != null
                 ? writeBeanAndParentsFieldSpecs(writer, settings, model, emittedSoFar, parentBean)
-                : new HashSet<TsBeanModel>();
+                : new HashSet<>();
         final String parentClassName = parentBean != null
                 ? getBeanModelClassName(parentBean) + "Fields"
                 : "Fields";

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/DefaultsFromInstanceExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/DefaultsFromInstanceExtension.java
@@ -8,6 +8,7 @@ import cz.habarta.typescript.generator.compiler.TsModelTransformer;
 import cz.habarta.typescript.generator.emitter.*;
 import cz.habarta.typescript.generator.parser.BeanModel;
 import cz.habarta.typescript.generator.parser.PropertyModel;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
@@ -20,7 +21,6 @@ import java.util.stream.Collectors;
  * it gets those values from class instance (object) created using default (parameter-less) constructor.
  */
 public class DefaultsFromInstanceExtension extends Extension {
-
     @Override
     public EmitterExtensionFeatures getFeatures() {
         final EmitterExtensionFeatures features = new EmitterExtensionFeatures();

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/JsonDeserializationExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/JsonDeserializationExtension.java
@@ -10,6 +10,7 @@ import cz.habarta.typescript.generator.compiler.SymbolTable;
 import cz.habarta.typescript.generator.compiler.TsModelTransformer;
 import cz.habarta.typescript.generator.emitter.*;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 
 public class JsonDeserializationExtension extends Extension {
-
     public static final String CFG_USE_JSON_DESERIALIZATION_IN_JAXRS_APPLICATION_CLIENT = "useJsonDeserializationInJaxrsApplicationClient";
 
     private boolean useJsonDeserializationInJaxrsApplicationClient = false;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/TypeGuardsForJackson2PolymorphismExtension.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/ext/TypeGuardsForJackson2PolymorphismExtension.java
@@ -11,7 +11,6 @@ import cz.habarta.typescript.generator.emitter.TsBeanModel;
 import cz.habarta.typescript.generator.emitter.TsModel;
 
 public class TypeGuardsForJackson2PolymorphismExtension extends EmitterExtension {
-
     @Override
     public EmitterExtensionFeatures getFeatures() {
         final EmitterExtensionFeatures features = new EmitterExtensionFeatures();

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/BeanModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/BeanModel.java
@@ -2,13 +2,13 @@
 package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 public class BeanModel extends DeclarationModel {
-
     private final Type parent;
     private final List<Class<?>> taggedUnionClasses;
     private final String discriminantProperty;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/DeclarationModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/DeclarationModel.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.parser;
 import java.util.List;
 
 public abstract class DeclarationModel {
-
     protected final Class<?> origin;
     protected final List<String> comments;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/DeprecationEnricher.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/DeprecationEnricher.java
@@ -4,6 +4,7 @@ package cz.habarta.typescript.generator.parser;
 import cz.habarta.typescript.generator.compiler.EnumMemberModel;
 import cz.habarta.typescript.generator.util.DeprecationUtils;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -13,7 +14,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class DeprecationEnricher {
-
     public Model enrichModel(Model model) {
         final List<BeanModel> beans = mapList(model.getBeans(), this::enrichBean);
         final List<EnumModel> enums = mapList(model.getEnums(), this::enrichEnum);

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/EnumModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/EnumModel.java
@@ -3,10 +3,10 @@ package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.compiler.EnumKind;
 import cz.habarta.typescript.generator.compiler.EnumMemberModel;
+
 import java.util.List;
 
 public class EnumModel extends DeclarationModel {
-
     private final EnumKind kind;
     private final List<EnumMemberModel> members;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Jackson2Parser.java
@@ -33,6 +33,7 @@ import cz.habarta.typescript.generator.type.JUnionType;
 import cz.habarta.typescript.generator.util.Pair;
 import cz.habarta.typescript.generator.util.PropertyMember;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
@@ -44,7 +45,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class Jackson2Parser extends ModelParser {
-
     public static class Jackson2ParserFactory extends ModelParser.Factory {
 
         private final boolean useJaxbAnnotations;
@@ -729,7 +729,8 @@ public class Jackson2Parser extends ModelParser {
         if (jsonFormat != null && jsonFormat.shape() == JsonFormat.Shape.OBJECT) {
             return parseBean(sourceClass, classComments);
         }
-        final boolean isNumberBased = jsonFormat != null && (jsonFormat.shape() == JsonFormat.Shape.NUMBER ||
+        final boolean isNumberBased = jsonFormat != null && (
+                jsonFormat.shape() == JsonFormat.Shape.NUMBER ||
                 jsonFormat.shape() == JsonFormat.Shape.NUMBER_FLOAT ||
                 jsonFormat.shape() == JsonFormat.Shape.NUMBER_INT);
 
@@ -749,8 +750,7 @@ public class Jackson2Parser extends ModelParser {
                 try {
                     constant.setAccessible(true);
                     final String enumJson = objectMapper.writeValueAsString(constant.get(null));
-                    value = objectMapper.readValue(enumJson, new TypeReference<Object>() {
-                    });
+                    value = objectMapper.readValue(enumJson, new TypeReference<>() {});
                 } catch (Throwable e) {
                     TypeScriptGenerator.getLogger().error(String.format("Cannot get enum value for constant '%s.%s'",
                             enumClass.getName(), constant.getName()));

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Javadoc.java
@@ -10,13 +10,13 @@ import cz.habarta.typescript.generator.xmldoclet.Class;
 import cz.habarta.typescript.generator.xmldoclet.Enum;
 import cz.habarta.typescript.generator.xmldoclet.Package;
 import jakarta.xml.bind.JAXB;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 public class Javadoc {
-
     private final String newline;
     private final List<Root> dRoots;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/JaxrsApplicationParser.java
@@ -9,6 +9,7 @@ import cz.habarta.typescript.generator.util.Utils;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.*;
+
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
@@ -20,7 +21,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class JaxrsApplicationParser extends RestApplicationParser {
-
     public static class Factory extends RestApplicationParser.Factory {
 
         @Override

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/MethodModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/MethodModel.java
@@ -7,7 +7,6 @@ import java.util.Collections;
 import java.util.List;
 
 public class MethodModel {
-
     protected final Class<?> originClass;
     protected final String name;
     protected final List<MethodParameterModel> parameters;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/MethodParameterModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/MethodParameterModel.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.parser;
 import java.lang.reflect.Type;
 
 public class MethodParameterModel {
-
     private final String name;
     private final Type type;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Model.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Model.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Objects;
 
 public class Model {
-
     private final List<BeanModel> beans;
     private final List<EnumModel> enums;
     private final List<RestApplicationModel> restApplications;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/ModelParser.java
@@ -8,6 +8,7 @@ import cz.habarta.typescript.generator.util.AnnotationGetter;
 import cz.habarta.typescript.generator.util.GenericsResolver;
 import cz.habarta.typescript.generator.util.PropertyMember;
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.util.*;
@@ -16,7 +17,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public abstract class ModelParser {
-
     protected final Settings settings;
     private final Javadoc javadoc;
     private final DeprecationEnricher deprecationEnricher;
@@ -25,14 +25,11 @@ public abstract class ModelParser {
     private final List<RestApplicationParser> restApplicationParsers;
 
     public static abstract class Factory {
-
         public TypeProcessor getSpecificTypeProcessor() {
             return null;
         }
 
-        public abstract ModelParser create(Settings settings, TypeProcessor commonTypeProcessor,
-                List<RestApplicationParser> restApplicationParsers);
-
+        public abstract ModelParser create(Settings settings, TypeProcessor commonTypeProcessor, List<RestApplicationParser> restApplicationParsers);
     }
 
     public ModelParser(Settings settings, TypeProcessor commonTypeProcessor,
@@ -84,8 +81,7 @@ public abstract class ModelParser {
                 continue;
             }
 
-            final TypeProcessor.Result result = commonTypeProcessor.processTypeInTemporaryContext(sourceType.type, null,
-                    settings);
+            final TypeProcessor.Result result = commonTypeProcessor.processTypeInTemporaryContext(sourceType.type, null, settings);
             if (result != null) {
                 if (sourceType.type instanceof Class<?> cls
                         && result.getTsType() instanceof TsType.ReferenceType referenceType) {
@@ -177,8 +173,7 @@ public abstract class ModelParser {
         if (settings.optionalProperties == OptionalProperties.all) {
             return true;
         }
-        if (settings.optionalProperties == null
-                || settings.optionalProperties == OptionalProperties.useSpecifiedAnnotations) {
+        if (settings.optionalProperties == null || settings.optionalProperties == OptionalProperties.useSpecifiedAnnotations) {
             if (!settings.optionalAnnotations.isEmpty()) {
                 return Utils.hasAnyAnnotation(propertyMember::getAnnotation, settings.optionalAnnotations);
             }
@@ -220,8 +215,7 @@ public abstract class ModelParser {
         for (Class<?> cls : classes) {
             typeQueue.add(new SourceType<>(cls, usedInClass, name));
         }
-        return new PropertyModel(name, resolvedType, optional, access, originalMember, pullProperties, typeContext,
-                comments);
+        return new PropertyModel(name, resolvedType, optional, access, originalMember, pullProperties, typeContext, comments);
     }
 
     public static boolean containsProperty(List<PropertyModel> properties, String propertyName) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/PathTemplate.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/PathTemplate.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.compiler.ModelCompiler;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -9,7 +10,6 @@ import java.util.regex.Pattern;
 
 // see org.glassfish.jersey.uri.internal.UriTemplateParser
 public class PathTemplate {
-
     private final List<Part> parts;
 
     private PathTemplate(List<Part> parts) {
@@ -22,16 +22,18 @@ public class PathTemplate {
 
     public static PathTemplate parse(String path) {
         final List<Part> parts = new ArrayList<>();
-        final String pattern = ""
-                + "\\{"
-                + "\\s*"
-                + "(?<ParamName>\\w[\\w\\.-]*)"
-                + "\\s*"
-                + "(:"
-                + "\\s*"
-                + "(?<ParamRegex>[^{}\\s]+(\\{[^{}]*\\}[^{}]*)*)" // this handles RegExp which may contain '{}' quantifiers
-                + "\\s*)?"
-                + "\\}";
+        // this handles RegExp which may contain '{}' quantifiers
+        final String pattern = """
+                \
+                \\{\
+                \\s*\
+                (?<ParamName>\\w[\\w\\.-]*)\
+                \\s*\
+                (:\
+                \\s*\
+                (?<ParamRegex>[^{}\\s]+(\\{[^{}]*\\}[^{}]*)*)\
+                \\s*)?\
+                \\}""";
         final Matcher matcher = Pattern.compile(pattern).matcher(path);
         int index = 0;
         while (matcher.find()) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/PropertyAccess.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/PropertyAccess.java
@@ -2,7 +2,6 @@
 package cz.habarta.typescript.generator.parser;
 
 public enum PropertyAccess {
-
     ReadOnly,
     WriteOnly,
     ReadWrite,

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/PropertyModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/PropertyModel.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 
 public class PropertyModel {
-
     private final String name;
     private final Type type;
     private final boolean optional;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/RestApplicationModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/RestApplicationModel.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Objects;
 
 public class RestApplicationModel {
-
     private final RestApplicationType type;
     private String applicationPath;
     private String applicationName;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/RestApplicationType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/RestApplicationType.java
@@ -2,16 +2,14 @@
 package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.Settings;
+
 import java.util.function.Function;
 
 public enum RestApplicationType {
-
     Jaxrs(settings -> settings.generateJaxrsApplicationInterface, settings -> settings.generateJaxrsApplicationClient),
-    Spring(settings -> settings.generateSpringApplicationInterface,
-            settings -> settings.generateSpringApplicationClient);
+    Spring(settings -> settings.generateSpringApplicationInterface, settings -> settings.generateSpringApplicationClient);
 
-    RestApplicationType(Function<Settings, Boolean> generateInterface,
-            Function<Settings, Boolean> generateClient) {
+    RestApplicationType(Function<Settings, Boolean> generateInterface, Function<Settings, Boolean> generateClient) {
         this.generateInterface = generateInterface;
         this.generateClient = generateClient;
     }

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/RestMethodModel.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/RestMethodModel.java
@@ -6,7 +6,6 @@ import java.lang.reflect.Type;
 import java.util.List;
 
 public class RestMethodModel extends MethodModel {
-
     private final Class<?> rootResource;
     private final String httpMethod;
     private final String path;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/RestQueryParam.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/RestQueryParam.java
@@ -2,7 +2,6 @@
 package cz.habarta.typescript.generator.parser;
 
 public abstract class RestQueryParam {
-
     public boolean required;
 
     RestQueryParam(boolean required) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/SourceType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/SourceType.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.parser;
 import java.lang.reflect.Type;
 
 public class SourceType<T extends Type> {
-
     public final T type;
     public final Class<?> usedInClass;
     public final String usedInMember;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Swagger.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/Swagger.java
@@ -2,6 +2,7 @@
 package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -10,7 +11,6 @@ import java.util.*;
 import java.util.function.Supplier;
 
 public class Swagger {
-
     public static SwaggerOperation parseSwaggerAnnotations(Method method) {
         return firstResult(
                 () -> parseSwaggerAnnotations3(method),
@@ -77,8 +77,7 @@ public class Swagger {
         // @Operation
         if (operationAnnotation != null) {
             swaggerOperation.hidden = Utils.getAnnotationElementValue(operationAnnotation, "hidden", Boolean.class);
-            swaggerOperation.comment = Utils.getAnnotationElementValue(operationAnnotation, "description",
-                    String.class);
+            swaggerOperation.comment = Utils.getAnnotationElementValue(operationAnnotation, "description", String.class);
             swaggerOperation.comment = swaggerOperation.comment.isEmpty() ? null : swaggerOperation.comment;
         }
         // @ApiResponses
@@ -210,8 +209,7 @@ public class Swagger {
         return firstResult(supplier1, supplier2, null);
     }
 
-    private static <T> T firstResult(Supplier<? extends T> supplier1, Supplier<? extends T> supplier2,
-            T defaultResult) {
+    private static <T> T firstResult(Supplier<? extends T> supplier1, Supplier<? extends T> supplier2, T defaultResult) {
         final T result1 = supplier1.get();
         if (result1 != null) {
             return result1;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/TypeParser.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/parser/TypeParser.java
@@ -3,11 +3,6 @@ package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.type.*;
 import cz.habarta.typescript.generator.util.Utils;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.*;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import kotlin.Metadata;
 import kotlin.NotImplementedError;
 import kotlin.jvm.JvmClassMappingKt;
@@ -15,8 +10,13 @@ import kotlin.reflect.*;
 import kotlin.reflect.full.KClasses;
 import kotlin.reflect.jvm.ReflectJvmMapping;
 
-public class TypeParser {
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+public class TypeParser {
     private final JavaTypeParser javaTypeParser;
     private final KotlinTypeParser kotlinTypeParser;
 
@@ -27,11 +27,8 @@ public class TypeParser {
 
     private interface LanguageTypeParser {
         Type getFieldType(Field field);
-
         Type getMethodReturnType(Method method);
-
         List<Type> getMethodParameterTypes(Method method);
-
         List<Type> getConstructorParameterTypes(Constructor<?> constructor);
     }
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/type/JGenericArrayType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/type/JGenericArrayType.java
@@ -6,7 +6,6 @@ import java.lang.reflect.Type;
 import java.util.Objects;
 
 public class JGenericArrayType implements GenericArrayType {
-
     private final Type genericComponentType;
 
     public JGenericArrayType(Type genericComponentType) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/type/JParameterizedType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/type/JParameterizedType.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class JParameterizedType implements ParameterizedType {
-
     private final Type rawType;
     private final Type[] actualTypeArguments;
     private final Type ownerType;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/type/JTypeVariable.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/type/JTypeVariable.java
@@ -9,7 +9,6 @@ import java.lang.reflect.TypeVariable;
 import java.util.Objects;
 
 public class JTypeVariable<D extends GenericDeclaration> implements TypeVariable<D> {
-
     private final D genericDeclaration; // should not be null but for Kotlin KTypeParameter we don't have it
     private final String name;
     private Type[] bounds;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/type/JTypeWithNullability.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/type/JTypeWithNullability.java
@@ -2,11 +2,11 @@
 package cz.habarta.typescript.generator.type;
 
 import cz.habarta.typescript.generator.util.Utils;
+
 import java.lang.reflect.Type;
 import java.util.Objects;
 
 public class JTypeWithNullability implements Type {
-
     private final Type type;
     private final boolean isNullable;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/type/JUnionType.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/type/JUnionType.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class JUnionType implements Type {
-
     private final List<Type> types;
 
     public JUnionType(Type... types) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/GenericsResolver.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/GenericsResolver.java
@@ -8,7 +8,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class GenericsResolver {
-
     public static Type resolveField(Class<?> cls, Field field) {
         final Type fieldType = field.getGenericType();
         return resolveType(cls, fieldType, field.getDeclaringClass());
@@ -35,6 +34,19 @@ public class GenericsResolver {
                     .collect(Collectors.toList());
         }
         return result;
+    }
+
+    /**
+     * Receives a given generic class/interface (that have generic type parameters) and returns a List with the type parameter names.
+     * For instance, if we have a generic type Map&lt;K,V&gt;, this method will return the string K, V;.
+     * @param genericClass a class/interface that have generic type parameters
+     * @return a List of the type parameter names
+     */
+    public static List<String> typeParameterNameList(final Class<?> genericClass){
+        return
+            Arrays.stream(genericClass.getTypeParameters())
+                  .map(TypeVariable::getName)
+                  .collect(Collectors.toList());
     }
 
     public static List<Type> resolveBaseGenericVariables(Class<?> baseClass, Type contextType) {

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Pair.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Pair.java
@@ -4,7 +4,6 @@ package cz.habarta.typescript.generator.util;
 import java.util.Objects;
 
 public class Pair<T1, T2> {
-
     private final T1 value1;
     private final T2 value2;
 

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/PropertyMember.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/PropertyMember.java
@@ -8,7 +8,6 @@ import java.lang.reflect.Type;
 import java.util.Objects;
 
 public class PropertyMember {
-
     private final AnnotatedElement annotatedElement;
     private final Type type;
     private final AnnotatedType annotatedType;

--- a/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
+++ b/typescript-generator-core/src/main/java/cz/habarta/typescript/generator/util/Utils.java
@@ -10,6 +10,7 @@ import cz.habarta.typescript.generator.type.JGenericArrayType;
 import cz.habarta.typescript.generator.type.JParameterizedType;
 import cz.habarta.typescript.generator.type.JTypeWithNullability;
 import cz.habarta.typescript.generator.type.JUnionType;
+
 import java.io.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
@@ -25,7 +26,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public final class Utils {
-
     private Utils() {
     }
 
@@ -97,11 +97,8 @@ public final class Utils {
     public static <T> Collector<T, ?, Collection<T>> toReversedCollection() {
         return Collector.<T, ArrayDeque<T>, Collection<T>>of(
                 ArrayDeque::new,
-                ArrayDeque::addFirst,
-                (deque1, deque2) -> {
-                    deque2.addAll(deque1);
-                    return deque2;
-                },
+                (deque, item) -> deque.addFirst(item),
+                (deque1, deque2) -> { deque2.addAll(deque1); return deque2; },
                 deque -> deque);
     }
 
@@ -200,8 +197,7 @@ public final class Utils {
                 new Class<?>[] { clazz },
                 (proxy, method, args) -> {
                     try {
-                        final Method fallbackMethod = object.getClass().getMethod(method.getName(),
-                                method.getParameterTypes());
+                        final Method fallbackMethod = object.getClass().getMethod(method.getName(), method.getParameterTypes());
                         return fallbackMethod.invoke(object, args);
                     } catch (ReflectiveOperationException e) {
                         return null;
@@ -267,8 +263,7 @@ public final class Utils {
     }
 
     private static final Map<String, Class<?>> primitiveTypes = Stream
-            .of(byte.class, short.class, int.class, long.class, float.class, double.class, boolean.class, char.class,
-                    void.class)
+            .of(byte.class, short.class, int.class, long.class, float.class, double.class, boolean.class, char.class, void.class)
             .collect(Utils.toMap(Class::getName, cls -> cls));
 
     public static Class<?> getPrimitiveType(String typeName) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ClassesTest.java
@@ -1,88 +1,95 @@
 
 package cz.habarta.typescript.generator;
 
-import java.util.Arrays;
-import java.util.List;
-import javax.annotation.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+
 @SuppressWarnings("unused")
 public class ClassesTest {
-
     @Test
     public void testInvalidSettings() {
         final Settings settings = TestUtils.settings();
         settings.mapClasses = ClassMapping.asClasses;
-        Assertions.assertThrows(Exception.class,
-                () -> new TypeScriptGenerator(settings).generateTypeScript(Input.from()));
+        Assertions.assertThrows(Exception.class, () -> new TypeScriptGenerator(settings).generateTypeScript(Input.from()));
     }
 
     @Test
     public void testClass() {
         testOutput(A.class,
-                "class A {\n" +
-                        "    a: string;\n" +
-                        "}");
+                   """
+                           class A {
+                               a: string;
+                           }"""
+        );
     }
 
     @Test
     public void testInheritedClass() {
         // A and B order is important
         testOutput(B.class,
-                "class A {\n" +
-                        "    a: string;\n" +
-                        "}\n" +
-                        "\n" +
-                        "class B extends A {\n" +
-                        "    b: string;\n" +
-                        "}");
+                   """
+                           class A {
+                               a: string;
+                           }
+                           
+                           class B extends A {
+                               b: string;
+                           }"""
+        );
     }
 
     @Test
     public void testClassImplementsInterface() {
         testOutput(E.class,
-                "class E implements D {\n" +
-                        "    c: string;\n" +
-                        "    d: string;\n" +
-                        "    e: string;\n" +
-                        "}\n" +
-                        "\n" +
-                        "interface D extends C {\n" +
-                        "    d: string;\n" +
-                        "}\n" +
-                        "\n" +
-                        "interface C {\n" +
-                        "    c: string;\n" +
-                        "}");
+                   """
+                           class E implements D {
+                               c: string;
+                               d: string;
+                               e: string;
+                           }
+                           
+                           interface D extends C {
+                               d: string;
+                           }
+                           
+                           interface C {
+                               c: string;
+                           }"""
+        );
     }
 
     @Test
     public void testComplexHierarchy() {
         // Q3 and Q5 order is important
         testOutput(Q5.class,
-                "class Q3 implements Q2 {\n" +
-                        "    q1: string;\n" +
-                        "    q2: string;\n" +
-                        "    q3: string;\n" +
-                        "}\n" +
-                        "\n" +
-                        "class Q5 extends Q3 implements Q2, Q4 {\n" +
-                        "    q4: string;\n" +
-                        "    q5: string;\n" +
-                        "}\n" +
-                        "\n" +
-                        "interface Q2 extends Q1 {\n" +
-                        "    q2: string;\n" +
-                        "}\n" +
-                        "\n" +
-                        "interface Q4 {\n" +
-                        "    q4: string;\n" +
-                        "}\n" +
-                        "\n" +
-                        "interface Q1 {\n" +
-                        "    q1: string;\n" +
-                        "}");
+                   """
+                           class Q3 implements Q2 {
+                               q1: string;
+                               q2: string;
+                               q3: string;
+                           }
+                           
+                           class Q5 extends Q3 implements Q2, Q4 {
+                               q4: string;
+                               q5: string;
+                           }
+                           
+                           interface Q2 extends Q1 {
+                               q2: string;
+                           }
+                           
+                           interface Q4 {
+                               q4: string;
+                           }
+                           
+                           interface Q1 {
+                               q1: string;
+                           }"""
+        );
     }
 
     private static void testOutput(Class<?> inputClass, String expected) {
@@ -140,22 +147,25 @@ public class ClassesTest {
                         "**Bc",
                         "**Bi",
                         "**Derived1",
-                        "**Derived2"),
-                ""
-                        + "class Bc {\n"
-                        + "    x: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "interface Bi {\n"
-                        + "    y: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "class Derived1 extends Bc implements Bi {\n"
-                        + "    y: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "class Derived2 extends Derived1 {\n"
-                        + "}");
+                        "**Derived2"
+                ),
+                """
+                        \
+                        class Bc {
+                            x: string;
+                        }
+                        
+                        interface Bi {
+                            y: string;
+                        }
+                        
+                        class Derived1 extends Bc implements Bi {
+                            y: string;
+                        }
+                        
+                        class Derived2 extends Derived1 {
+                        }"""
+        );
     }
 
     @Test
@@ -163,23 +173,26 @@ public class ClassesTest {
         testClassPatterns(
                 Arrays.asList(
                         "**Derived1",
-                        "**Derived2"),
-                ""
-                        + "interface Bc {\n"
-                        + "    x: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "interface Bi {\n"
-                        + "    y: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "class Derived1 implements Bc, Bi {\n"
-                        + "    x: string;\n"
-                        + "    y: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "class Derived2 extends Derived1 {\n"
-                        + "}");
+                        "**Derived2"
+                ),
+                """
+                        \
+                        interface Bc {
+                            x: string;
+                        }
+                        
+                        interface Bi {
+                            y: string;
+                        }
+                        
+                        class Derived1 implements Bc, Bi {
+                            x: string;
+                            y: string;
+                        }
+                        
+                        class Derived2 extends Derived1 {
+                        }"""
+        );
     }
 
     @Test
@@ -187,23 +200,26 @@ public class ClassesTest {
         testClassPatterns(
                 Arrays.asList(
                         "**Bc",
-                        "**Derived2"),
-                ""
-                        + "class Bc {\n"
-                        + "    x: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "interface Bi {\n"
-                        + "    y: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "interface Derived1 extends Bc, Bi {\n"
-                        + "}\n"
-                        + "\n"
-                        + "class Derived2 implements Derived1 {\n"
-                        + "    x: string;\n"
-                        + "    y: string;\n"
-                        + "}");
+                        "**Derived2"
+                ),
+                """
+                        \
+                        class Bc {
+                            x: string;
+                        }
+                        
+                        interface Bi {
+                            y: string;
+                        }
+                        
+                        interface Derived1 extends Bc, Bi {
+                        }
+                        
+                        class Derived2 implements Derived1 {
+                            x: string;
+                            y: string;
+                        }"""
+        );
     }
 
     @Test
@@ -211,22 +227,25 @@ public class ClassesTest {
         testClassPatterns(
                 Arrays.asList(
                         "**Bc",
-                        "**Derived1"),
-                ""
-                        + "class Bc {\n"
-                        + "    x: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "interface Bi {\n"
-                        + "    y: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "class Derived1 extends Bc implements Bi {\n"
-                        + "    y: string;\n"
-                        + "}\n"
-                        + "\n"
-                        + "interface Derived2 extends Derived1 {\n"
-                        + "}");
+                        "**Derived1"
+                ),
+                """
+                        \
+                        class Bc {
+                            x: string;
+                        }
+                        
+                        interface Bi {
+                            y: string;
+                        }
+                        
+                        class Derived1 extends Bc implements Bi {
+                            y: string;
+                        }
+                        
+                        interface Derived2 extends Derived1 {
+                        }"""
+        );
     }
 
     private static void testClassPatterns(List<String> mapClassesAsClassesPatterns, String expected) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CovariantPropertiesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CovariantPropertiesTest.java
@@ -1,32 +1,34 @@
 
 package cz.habarta.typescript.generator;
 
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class CovariantPropertiesTest {
+import java.util.List;
 
+public class CovariantPropertiesTest {
     @Test
     public void test() {
         final Settings settings = TestUtils.settings();
         settings.sortDeclarations = true;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Dog.class));
-        final String expected = "interface Animal {\n" +
-                "    allFood: Food[];\n" +
-                "    todaysFood: Food;\n" +
-                "}\n" +
-                "\n" +
-                "interface Dog extends Animal {\n" +
-                "    allFood: DogFood[];\n" +
-                "    todaysFood: DogFood;\n" +
-                "}\n" +
-                "\n" +
-                "interface DogFood extends Food {\n" +
-                "}\n" +
-                "\n" +
-                "interface Food {\n" +
-                "}";
+        final String expected =
+                """
+                        interface Animal {
+                            allFood: Food[];
+                            todaysFood: Food;
+                        }
+                        
+                        interface Dog extends Animal {
+                            allFood: DogFood[];
+                            todaysFood: DogFood;
+                        }
+                        
+                        interface DogFood extends Food {
+                        }
+                        
+                        interface Food {
+                        }""";
         Assertions.assertEquals(expected.replace('\'', '"'), output.trim());
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeAliasesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeAliasesTest.java
@@ -1,13 +1,13 @@
 
 package cz.habarta.typescript.generator;
 
-import java.util.Collections;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 @SuppressWarnings("unused")
 public class CustomTypeAliasesTest {
-
     @Test
     public void testGeneric() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeConversionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeConversionTest.java
@@ -1,17 +1,17 @@
 package cz.habarta.typescript.generator;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Date;
 import java.util.List;
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CustomTypeConversionTest {
-
     @Test
     public void testCustomTypeConversion() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeMappingTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/CustomTypeMappingTest.java
@@ -5,13 +5,16 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("unused")
@@ -33,6 +36,48 @@ public class CustomTypeMappingTest {
         assertTrue(output.contains("calendar1: myModule.MyCalendar;"));
     }
 
+    /**
+     * Checks that the custom type mapping works for non-nested generic parameters.
+     * That is, each type parameter is not generic by itself.
+     */
+    @Test
+    public void testSimpleGenericParameter() {
+        class ClassWithNonNestedGenericTypes {
+            public List<String> stringList;
+            public List<BigDecimal> bigDecimalList;
+        }
+
+        final Settings settings = TestUtils.settings();
+        settings.quotes = "'";
+        settings.customTypeMappings.put("java.util.List<BigDecimal>", "number[]");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithNonNestedGenericTypes.class));
+        System.out.println(output);
+
+        assertTrue(output.contains("stringList: string[];"));
+        assertTrue(output.contains("bigDecimalList: number[];"));
+    }
+
+    /**
+     * Checks that the custom type mapping works for nested generic parameters.
+     * That is, a type parameter is generic by itself.
+     */
+    @Test
+    public void testNestedGenericParameter() {
+        class ClassWithNestedGenericTypes {
+            public List<String> stringList;
+            public List<List<BigDecimal>> bigDecimalMatrix;
+        }
+
+        final Settings settings = TestUtils.settings();
+        settings.quotes = "'";
+        settings.customTypeMappings.put("java.util.List<java.util.List<BigDecimal>>", "number[][]");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ClassWithNestedGenericTypes.class));
+        System.out.println(output);
+
+        assertTrue(output.contains("stringList: string[];"));
+        assertTrue(output.contains("bigDecimalMatrix: number[][];"));
+    }
+
     private static class CustomTypesUsage {
         public Date date1;
         public Calendar calendar1;
@@ -40,13 +85,12 @@ public class CustomTypeMappingTest {
 
     @Test
     public void testEnumAsMap() throws Exception {
-        //        final ObjectMapper objectMapper = new ObjectMapper();
-        //        final String json = objectMapper.writeValueAsString(MyEnum.MY_FIRST_VALUE);
-        //        System.out.println(json);
+//        final ObjectMapper objectMapper = new ObjectMapper();
+//        final String json = objectMapper.writeValueAsString(MyEnum.MY_FIRST_VALUE);
+//        System.out.println(json);
 
         final Settings settings = TestUtils.settings();
-        settings.customTypeMappings = Collections.singletonMap(
-                "cz.habarta.typescript.generator.CustomTypeMappingTest$MyEnum", "{ code: string, definition: string }");
+        settings.customTypeMappings = Collections.singletonMap("cz.habarta.typescript.generator.CustomTypeMappingTest$MyEnum", "{ code: string, definition: string }");
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(MyInterfUsingEnum.class));
         assertTrue(output.contains("someValue: { code: string, definition: string }"));
     }
@@ -57,17 +101,14 @@ public class CustomTypeMappingTest {
     @Test
     public void testSuperTypeString() throws Exception {
         final Settings settings = TestUtils.settings();
-        settings.customTypeMappings = Collections
-                .singletonMap("cz.habarta.typescript.generator.CustomTypeMappingTest$BaseCustomMapping", "string");
-        final String output = new TypeScriptGenerator(settings)
-                .generateTypeScript(Input.from(InterfaceUsingSubCustomMapping.class));
+        settings.customTypeMappings = Collections.singletonMap("cz.habarta.typescript.generator.CustomTypeMappingTest$BaseCustomMapping", "string");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(InterfaceUsingSubCustomMapping.class));
         assertTrue(output.contains("sub: SubCustomMapping;"));
     }
 
     @JsonSerialize(using = CodedValueSerializer.class)
     public interface CodedValue {
         String getCode();
-
         String getDefinition();
     }
 
@@ -99,7 +140,6 @@ public class CustomTypeMappingTest {
     }
 
     public static class CodedValueSerializer extends StdSerializer<CodedValue> {
-
         private static final long serialVersionUID = 1L;
 
         public CodedValueSerializer() {
@@ -132,10 +172,9 @@ public class CustomTypeMappingTest {
     @Test
     public void testGenericClassWithCustomMapping() {
         final Settings settings = TestUtils.settings();
-        settings.customTypeMappings = Collections.singletonMap(
-                "cz.habarta.typescript.generator.CustomTypeMappingTest$GenericClass<D>", "CustomGenericClass<D>");
+        settings.customTypeMappings = Collections.singletonMap("cz.habarta.typescript.generator.CustomTypeMappingTest$GenericClass<D>", "CustomGenericClass<D>");
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(GenericClass.class));
-        Assertions.assertEquals("", output);
+        assertEquals("", output);
     }
 
     static class GenericClass<D> {
@@ -147,11 +186,10 @@ public class CustomTypeMappingTest {
         final Settings settings = TestUtils.settings();
         settings.customTypeMappings = Collections.singletonMap("long", "BigInt");
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(BigIntClass.class));
-        Assertions.assertTrue(output.contains("bigNumber: BigInt;"));
+        assertTrue(output.contains("bigNumber: BigInt;"));
     }
 
     private static class BigIntClass {
         public long bigNumber = Long.MAX_VALUE;
     }
-
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DateTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DateTest.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import java.time.*;
-import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class DateTest {
+import java.time.*;
+import java.util.*;
 
+public class DateTest {
     @Test
     public void testDate_forJavaUtilDate() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DecoratorsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DecoratorsTest.java
@@ -5,16 +5,16 @@ import cz.habarta.typescript.generator.compiler.ModelCompiler;
 import cz.habarta.typescript.generator.compiler.TsModelTransformer;
 import cz.habarta.typescript.generator.emitter.*;
 import cz.habarta.typescript.generator.parser.Model;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 public class DecoratorsTest {
-
     @Test
     public void testDecoratorOnClassAndProperty() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DefaultTypeProcessorTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DefaultTypeProcessorTest.java
@@ -1,24 +1,22 @@
 package cz.habarta.typescript.generator;
 
 import cz.habarta.typescript.generator.compiler.SymbolTable;
-import java.math.BigDecimal;
-import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings("unused")
 public class DefaultTypeProcessorTest {
-
     @Test
     public void testTypeConversion() {
         TypeProcessor converter = new DefaultTypeProcessor();
         final TypeProcessor.Context context = getTestContext(converter);
-        assertEquals(context.getSymbol(A.class).getFullName(),
-                converter.processType(A.class, context).getTsType().toString());
-        assertEquals(context.getSymbol(B.class).getFullName(),
-                converter.processType(B.class, context).getTsType().toString());
+        assertEquals(context.getSymbol(A.class).getFullName(), converter.processType(A.class, context).getTsType().toString());
+        assertEquals(context.getSymbol(B.class).getFullName(), converter.processType(B.class, context).getTsType().toString());
         assertEquals(TsType.Void, converter.processType(void.class, context).getTsType());
         assertEquals(TsType.Number, converter.processType(BigDecimal.class, context).getTsType());
         assertEquals(TsType.String, converter.processType(UUID.class, context).getTsType());
@@ -31,12 +29,9 @@ public class DefaultTypeProcessorTest {
     public void testWildcards() throws NoSuchFieldException {
         TypeProcessor converter = new DefaultTypeProcessor();
         final TypeProcessor.Context context = getTestContext(converter);
-        assertEquals("string[]",
-                converter.processType(C.class.getDeclaredField("x").getGenericType(), context).getTsType().toString());
-        assertEquals("any[]",
-                converter.processType(C.class.getDeclaredField("y").getGenericType(), context).getTsType().toString());
-        assertEquals("any[]",
-                converter.processType(C.class.getDeclaredField("z").getGenericType(), context).getTsType().toString());
+        assertEquals("string[]", converter.processType(C.class.getDeclaredField("x").getGenericType(), context).getTsType().toString());
+        assertEquals("any[]", converter.processType(C.class.getDeclaredField("y").getGenericType(), context).getTsType().toString());
+        assertEquals("any[]", converter.processType(C.class.getDeclaredField("z").getGenericType(), context).getTsType().toString());
     }
 
     private static class A {
@@ -59,8 +54,7 @@ public class DefaultTypeProcessorTest {
 
     @Test
     public void testRawTypes() {
-        final String output = new TypeScriptGenerator(TestUtils.settings())
-                .generateTypeScript(Input.from(DummyBean.class));
+        final String output = new TypeScriptGenerator(TestUtils.settings()).generateTypeScript(Input.from(DummyBean.class));
         Assertions.assertTrue(output.contains("rawListProperty: any[]"));
         Assertions.assertTrue(output.contains("rawMapProperty: { [index: string]: any }"));
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DeprecationUtilsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DeprecationUtilsTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DeprecationUtilsTest {
-
     @Deprecated
     private String a;
 
@@ -29,8 +28,7 @@ public class DeprecationUtilsTest {
 
     private static String getDeprecationText(String fieldName) {
         try {
-            final Deprecated deprecated = DeprecationUtilsTest.class.getDeclaredField(fieldName)
-                    .getAnnotation(Deprecated.class);
+            final Deprecated deprecated = DeprecationUtilsTest.class.getDeclaredField(fieldName).getAnnotation(Deprecated.class);
             return DeprecationUtils.convertToComment(deprecated);
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DummyBean.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DummyBean.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 @SuppressWarnings("rawtypes")
 public class DummyBean {
-
     public String firstProperty;
     public int intProperty;
     public Integer integerProperty;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DummyClassEnum.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DummyClassEnum.java
@@ -2,10 +2,10 @@ package cz.habarta.typescript.generator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+
 import java.util.Objects;
 
 public class DummyClassEnum {
-
     public static final DummyClassEnum ATYPE = new DummyClassEnum("ATYPE");
     public static final DummyClassEnum BTYPE = new DummyClassEnum("BTYPE");
     public static final DummyClassEnum CTYPE = new DummyClassEnum("CTYPE");
@@ -18,13 +18,8 @@ public class DummyClassEnum {
     }
 
     @JsonValue
-    public String getValue() {
-        return value;
-    }
+    public String getValue() { return value; }
 
     @Override
-    public String toString() {
-        return value;
-    }
-
+    public String toString() { return value; }
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DuplicatePropertyTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/DuplicatePropertyTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DuplicatePropertyTest {
-
     public static class DuplicateKindUsage {
         public DuplicateKind duplicateKind;
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/EnumTest.java
@@ -6,29 +6,31 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.habarta.typescript.generator.ext.ClassEnumExtension;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("unused")
 public class EnumTest {
-
     @Test
     public void testEnumAsUnion() {
         final Settings settings = TestUtils.settings();
         //        settings.mapEnum = EnumMapping.asUnion;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AClass.class));
-        final String expected = ("\n" +
-                "interface AClass {\n" +
-                "    direction: Direction;\n" +
-                "}\n" +
-                "\n" +
-                "type Direction = 'North' | 'East' | 'South' | 'West';\n").replace("'", "\"");
+        final String expected = (
+                """
+                        
+                        interface AClass {
+                            direction: Direction;
+                        }
+                        
+                        type Direction = 'North' | 'East' | 'South' | 'West';
+                        """
+                ).replace("'", "\"");
         assertEquals(expected, output);
     }
 
@@ -47,10 +49,13 @@ public class EnumTest {
         settings.quotes = "'";
         settings.mapEnum = EnumMapping.asInlineUnion;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AClass.class));
-        final String expected = "\n" +
-                "interface AClass {\n" +
-                "    direction: 'North' | 'East' | 'South' | 'West';\n" +
-                "}\n";
+        final String expected =
+                """
+                        
+                        interface AClass {
+                            direction: 'North' | 'East' | 'South' | 'West';
+                        }
+                        """;
         assertEquals(expected, output);
     }
 
@@ -59,17 +64,21 @@ public class EnumTest {
         final Settings settings = TestUtils.settings();
         settings.mapEnum = EnumMapping.asNumberBasedEnum;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AClass.class));
-        final String expected = ("\n" +
-                "interface AClass {\n" +
-                "    direction: Direction;\n" +
-                "}\n" +
-                "\n" +
-                "declare const enum Direction {\n" +
-                "    North,\n" +
-                "    East,\n" +
-                "    South,\n" +
-                "    West,\n" +
-                "}\n").replace("'", "\"");
+        final String expected = (
+                """
+                        
+                        interface AClass {
+                            direction: Direction;
+                        }
+                        
+                        declare const enum Direction {
+                            North,
+                            East,
+                            South,
+                            West,
+                        }
+                        """
+                ).replace("'", "\"");
         assertEquals(expected, output);
     }
 
@@ -78,16 +87,19 @@ public class EnumTest {
         final Settings settings = TestUtils.settings();
         settings.mapEnum = EnumMapping.asEnum;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(AClass.class));
-        final String expected = ("interface AClass {\n" +
-                "    direction: Direction;\n" +
-                "}\n" +
-                "\n" +
-                "declare const enum Direction {\n" +
-                "    North = 'North',\n" +
-                "    East = 'East',\n" +
-                "    South = 'South',\n" +
-                "    West = 'West',\n" +
-                "}").replace("'", "\"");
+        final String expected = (
+                """
+                        interface AClass {
+                            direction: Direction;
+                        }
+                        
+                        declare const enum Direction {
+                            North = 'North',
+                            East = 'East',
+                            South = 'South',
+                            West = 'West',
+                        }"""
+                ).replace("'", "\"");
         assertEquals(expected.trim(), output.trim());
     }
 
@@ -99,18 +111,23 @@ public class EnumTest {
         final ClassEnumExtension classEnumExtension = new ClassEnumExtension();
         classEnumExtension.setConfiguration(Collections.singletonMap("classEnumPattern", "Enum"));
         settings.extensions.add(classEnumExtension);
-        final String output = new TypeScriptGenerator(settings)
-                .generateTypeScript(Input.from(DummyEnum.class, DummyClassEnum.class));
-        final String expected = ("\ndeclare const enum DummyClassEnum {\n" +
-                "    ATYPE = 'ATYPE',\n" +
-                "    BTYPE = 'BTYPE',\n" +
-                "    CTYPE = 'CTYPE',\n" +
-                "}\n" +
-                "\ndeclare const enum DummyEnum {\n" +
-                "    Red = 'Red',\n" +
-                "    Green = 'Green',\n" +
-                "    Blue = 'Blue',\n" +
-                "}\n").replace("'", "\"");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DummyEnum.class, DummyClassEnum.class));
+        final String expected = (
+                """
+                        
+                        declare const enum DummyClassEnum {
+                            ATYPE = 'ATYPE',
+                            BTYPE = 'BTYPE',
+                            CTYPE = 'CTYPE',
+                        }
+                        
+                        declare const enum DummyEnum {
+                            Red = 'Red',
+                            Green = 'Green',
+                            Blue = 'Blue',
+                        }
+                        """
+                ).replace("'", "\"");
         assertEquals(expected.trim(), output.trim());
     }
 
@@ -123,23 +140,29 @@ public class EnumTest {
         final ClassEnumExtension classEnumExtension = new ClassEnumExtension();
         classEnumExtension.setConfiguration(Collections.singletonMap("classEnumPattern", "Enum"));
         settings.extensions.add(classEnumExtension);
-        final String output = new TypeScriptGenerator(settings)
-                .generateTypeScript(Input.from(DummyEnum.class, DummyClassEnum.class, DummyMixedCaseEnum.class));
-        final String expected = ("\ndeclare const enum DummyClassEnum {\n" +
-                "    Atype = 'ATYPE',\n" +
-                "    Btype = 'BTYPE',\n" +
-                "    Ctype = 'CTYPE',\n" +
-                "}\n" +
-                "\ndeclare const enum DummyEnum {\n" +
-                "    Red = 'Red',\n" +
-                "    Green = 'Green',\n" +
-                "    Blue = 'Blue',\n" +
-                "}\n" +
-                "\ndeclare const enum DummyMixedCaseEnum {\n" +
-                "    CamelCaseType = 'camelCaseType',\n" +
-                "    PascalCaseType = 'PascalCaseType',\n" +
-                "    UpperCaseType = 'UPPER_CASE_TYPE',\n" +
-                "}\n").replace("'", "\"");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DummyEnum.class, DummyClassEnum.class, DummyMixedCaseEnum.class));
+        final String expected = (
+                """
+                        
+                        declare const enum DummyClassEnum {
+                            Atype = 'ATYPE',
+                            Btype = 'BTYPE',
+                            Ctype = 'CTYPE',
+                        }
+                        
+                        declare const enum DummyEnum {
+                            Red = 'Red',
+                            Green = 'Green',
+                            Blue = 'Blue',
+                        }
+                        
+                        declare const enum DummyMixedCaseEnum {
+                            CamelCaseType = 'camelCaseType',
+                            PascalCaseType = 'PascalCaseType',
+                            UpperCaseType = 'UPPER_CASE_TYPE',
+                        }
+                        """
+        ).replace("'", "\"");
         assertEquals(expected.trim(), output.trim());
     }
 
@@ -148,8 +171,7 @@ public class EnumTest {
         final Settings settings = TestUtils.settings();
         settings.mapEnum = EnumMapping.asNumberBasedEnum;
         settings.enumMemberCasing = IdentifierCasing.camelCase;
-        final String output = new TypeScriptGenerator(settings)
-                .generateTypeScript(Input.from(DummyMixedCaseEnum.class));
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DummyMixedCaseEnum.class));
         assertTrue(output.contains("camelCaseType"));
         assertTrue(output.contains("pascalCaseType"));
         assertTrue(output.contains("upperCaseType"));
@@ -158,30 +180,39 @@ public class EnumTest {
     @Test
     public void testEnumWithJsonPropertyAnnotations() {
         final Settings settings = TestUtils.settings();
-        final String output = new TypeScriptGenerator(settings)
-                .generateTypeScript(Input.from(SideWithJsonPropertyAnnotations.class));
-        final String expected = ("\n" +
-                "type SideWithJsonPropertyAnnotations = 'left-side' | 'right-side';\n").replace("'", "\"");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideWithJsonPropertyAnnotations.class));
+        final String expected = (
+                """
+                        
+                        type SideWithJsonPropertyAnnotations = 'left-side' | 'right-side';
+                        """
+                ).replace("'", "\"");
         assertEquals(expected, output);
     }
 
     @Test
     public void testEnumWithJsonValueMethodAnnotation() {
         final Settings settings = TestUtils.settings();
-        final String output = new TypeScriptGenerator(settings)
-                .generateTypeScript(Input.from(SideWithJsonValueMethodAnnotation.class));
-        final String expected = ("\n" +
-                "type SideWithJsonValueMethodAnnotation = 'left-side' | 'right-side';\n").replace("'", "\"");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideWithJsonValueMethodAnnotation.class));
+        final String expected = (
+                """
+                        
+                        type SideWithJsonValueMethodAnnotation = 'left-side' | 'right-side';
+                        """
+                ).replace("'", "\"");
         assertEquals(expected, output);
     }
 
     @Test
     public void testEnumWithJsonValueFieldAnnotation() {
         final Settings settings = TestUtils.settings();
-        final String output = new TypeScriptGenerator(settings)
-                .generateTypeScript(Input.from(SideWithJsonValueFieldAnnotation.class));
-        final String expected = ("\n" +
-                "type SideWithJsonValueFieldAnnotation = 'left-side' | 'right-side';\n").replace("'", "\"");
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideWithJsonValueFieldAnnotation.class));
+        final String expected = (
+                """
+                        
+                        type SideWithJsonValueFieldAnnotation = 'left-side' | 'right-side';
+                        """
+                ).replace("'", "\"");
         assertEquals(expected, output);
     }
 
@@ -191,8 +222,12 @@ public class EnumTest {
         settings.jackson2Configuration = new Jackson2ConfigurationResolved();
         settings.jackson2Configuration.enumsUsingToString = true;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SideUsingToString.class));
-        final String expected = ("\n" +
-                "type SideUsingToString = 'toString:left-side' | 'toString:right-side';\n").replace("'", "\"");
+        final String expected = (
+                """
+                        
+                        type SideUsingToString = 'toString:left-side' | 'toString:right-side';
+                        """
+                ).replace("'", "\"");
         assertEquals(expected, output);
     }
 
@@ -200,8 +235,12 @@ public class EnumTest {
     public void testEmptyEnum() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(EmptyEnum.class));
-        final String expected = ("\n" +
-                "type EmptyEnum = never;\n").replace("'", "\"");
+        final String expected = (
+                """
+                        
+                        type EmptyEnum = never;
+                        """
+                );
         assertEquals(expected, output);
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/FullyQualifiedNamesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/FullyQualifiedNamesTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unused")
 public class FullyQualifiedNamesTest {
-
     @Test
     public void test() {
         final Settings settings = TestUtils.settings();
@@ -66,24 +65,25 @@ public class FullyQualifiedNamesTest {
         settings.mapClasses = ClassMapping.asClasses;
         settings.mapPackagesToNamespaces = true;
         settings.sortTypeDeclarations = true;
-        final String output = new TypeScriptGenerator(settings)
-                .generateTypeScript(Input.from(Outer.Inner.class, Outer.class));
-        final String expected = ""
-                + "namespace cz.habarta.typescript.generator.FullyQualifiedNamesTest {\n"
-                + "\n"
-                + "    export class Outer {\n"
-                + "        outer: string;\n"
-                + "    }\n"
-                + "\n"
-                + "}\n"
-                + "\n"
-                + "namespace cz.habarta.typescript.generator.FullyQualifiedNamesTest.Outer {\n"
-                + "\n"
-                + "    export class Inner {\n"
-                + "        inner: string;\n"
-                + "    }\n"
-                + "\n"
-                + "}\n";
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Outer.Inner.class, Outer.class));
+        final String expected = """
+                \
+                namespace cz.habarta.typescript.generator.FullyQualifiedNamesTest {
+                
+                    export class Outer {
+                        outer: string;
+                    }
+                
+                }
+                
+                namespace cz.habarta.typescript.generator.FullyQualifiedNamesTest.Outer {
+                
+                    export class Inner {
+                        inner: string;
+                    }
+                
+                }
+                """;
         Assertions.assertEquals(expected.trim(), output.trim());
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericCustomTypeMappingsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericCustomTypeMappingsTest.java
@@ -1,12 +1,13 @@
 
 package cz.habarta.typescript.generator;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unused")
 public class GenericCustomTypeMappingsTest {
@@ -187,5 +188,4 @@ public class GenericCustomTypeMappingsTest {
 
     private static abstract class Class3 extends AbstractClass<Date> implements Interface<Date> {
     }
-
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsResolverTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsResolverTest.java
@@ -1,24 +1,39 @@
 
 package cz.habarta.typescript.generator;
 
+import cz.habarta.typescript.generator.type.JParameterizedType;
 import cz.habarta.typescript.generator.type.JTypeVariable;
 import cz.habarta.typescript.generator.util.GenericsResolver;
 import cz.habarta.typescript.generator.util.Utils;
+import org.junit.jupiter.api.Test;
+
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GenericsResolverTest {
+    /**
+     * TODO: Not sure how to test this GenericsResolver.typeParameterNameList method. This test doesn't work.
+     */
+    @Test
+    void testTypeParameterNameList() {
+        // A type for a generic attribute that is List<BigDecimal>
+        final var javaType = new JParameterizedType(List.class, new Type[]{BigDecimal.class}, null);
+        final Class<?> attributeRawClass = Utils.getRawClassOrNull(javaType);
+        assertEquals(List.of("BigDecimal"), GenericsResolver.typeParameterNameList(attributeRawClass));
+        //assertEquals(List.of("List<BigDecimal>"), GenericsResolver.typeParameterNameList(classOfFieldWithNestedGeneric));
+    }
 
     @Test
     public void testStringField() throws Exception {
         final Class<?> cls = F1String.class;
         final Type type = GenericsResolver.resolveField(cls, cls.getField("field"));
-        Assertions.assertEquals(String.class, type);
+        assertEquals(String.class, type);
     }
 
     static class F1<T> {
@@ -32,7 +47,7 @@ public class GenericsResolverTest {
     public void testListOfStringField() throws Exception {
         final Class<?> cls = F2String.class;
         final Type type = GenericsResolver.resolveField(cls, cls.getField("list"));
-        Assertions.assertEquals(Utils.createParameterizedType(List.class, String.class), type);
+        assertEquals(Utils.createParameterizedType(List.class, String.class), type);
     }
 
     static class F2<T> {
@@ -46,7 +61,7 @@ public class GenericsResolverTest {
     public void testMapOfStringAndListOfLongField() throws Exception {
         final Class<?> cls = F3StringLong.class;
         final Type type = GenericsResolver.resolveField(cls, cls.getField("map"));
-        Assertions.assertEquals(Utils.createParameterizedType(Map.class, String.class,
+        assertEquals(Utils.createParameterizedType(Map.class, String.class,
                 Utils.createParameterizedType(List.class, Long.class)), type);
     }
 
@@ -61,21 +76,21 @@ public class GenericsResolverTest {
     public void testInheritancePath() throws Exception {
         final Class<?> cls = P123Number.class;
         final Type type = GenericsResolver.resolveField(cls, cls.getField("field"));
-        Assertions.assertEquals(Utils.createParameterizedType(List.class, Number.class), type);
+        assertEquals(Utils.createParameterizedType(List.class, Number.class), type);
     }
 
     @Test
     public void testInheritancePathWithUnresolvedVariable1() throws Exception {
         final Class<?> cls = P123.class;
         final Type type = GenericsResolver.resolveField(cls, cls.getField("field"));
-        Assertions.assertEquals(Utils.createParameterizedType(List.class, new JTypeVariable<>(P123.class, "B")), type);
+        assertEquals(Utils.createParameterizedType(List.class, new JTypeVariable<>(P123.class, "B")), type);
     }
 
     @Test
     public void testInheritancePathWithUnresolvedVariable2() throws Exception {
         final Class<?> cls = P12.class;
         final Type type = GenericsResolver.resolveField(cls, cls.getField("field"));
-        Assertions.assertEquals(new JTypeVariable<>(P12.class, "V"), type);
+        assertEquals(new JTypeVariable<>(P12.class, "V"), type);
     }
 
     static class P1<T> {
@@ -94,13 +109,13 @@ public class GenericsResolverTest {
     @Test
     public void testGenericVariableMappingToBase1() {
         final List<String> mappedTypeParameters = GenericsResolver.mapGenericVariablesToBase(R123.class, R1.class);
-        Assertions.assertEquals(Arrays.asList(null, null, "T"), mappedTypeParameters);
+        assertEquals(Arrays.asList(null, null, "T"), mappedTypeParameters);
     }
 
     @Test
     public void testGenericVariableMappingToBase2() {
         final List<String> mappedTypeParameters = GenericsResolver.mapGenericVariablesToBase(R12.class, R1.class);
-        Assertions.assertEquals(Arrays.asList("T", "S"), mappedTypeParameters);
+        assertEquals(Arrays.asList("T", "S"), mappedTypeParameters);
     }
 
     static class R1<S, T> {
@@ -115,28 +130,22 @@ public class GenericsResolverTest {
     @Test
     public void testResolvingGenericVariablesInContextType1() throws NoSuchFieldException {
         final Type contextType = MyClass.class.getField("property1").getGenericType();
-        final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(BaseClass.class,
-                contextType);
-        Assertions.assertEquals(Arrays.asList("java.lang.String", "java.lang.Integer"),
-                getTypeNames(resolvedTypeParameters));
+        final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(BaseClass.class, contextType);
+        assertEquals(Arrays.asList("java.lang.String", "java.lang.Integer"), getTypeNames(resolvedTypeParameters));
     }
 
     @Test
     public void testResolvingGenericVariablesInContextType3() throws NoSuchFieldException {
         final Type contextType = MyClass.class.getField("property3").getGenericType();
-        final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(BaseClass.class,
-                contextType);
-        Assertions.assertEquals(Arrays.asList("java.lang.Integer", "java.lang.Boolean"),
-                getTypeNames(resolvedTypeParameters));
+        final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(BaseClass.class, contextType);
+        assertEquals(Arrays.asList("java.lang.Integer", "java.lang.Boolean"), getTypeNames(resolvedTypeParameters));
     }
 
     @Test
     public void testResolvingGenericVariablesInContextTypeBase() throws NoSuchFieldException {
         final Type contextType = MyClass.class.getField("propertyBase").getGenericType();
-        final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(BaseClass.class,
-                contextType);
-        Assertions.assertEquals(Arrays.asList("java.lang.Integer", "java.lang.String"),
-                getTypeNames(resolvedTypeParameters));
+        final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(BaseClass.class, contextType);
+        assertEquals(Arrays.asList("java.lang.Integer", "java.lang.String"), getTypeNames(resolvedTypeParameters));
     }
 
     static class BaseClass<A, B> {
@@ -158,16 +167,14 @@ public class GenericsResolverTest {
     public void testResolvingRawUsage1() throws NoSuchFieldException {
         final Type contextType = RawUsage.class.getField("rawMap").getGenericType();
         final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(Map.class, contextType);
-        Assertions.assertEquals(Arrays.asList("java.lang.Object", "java.lang.Object"),
-                getTypeNames(resolvedTypeParameters));
+        assertEquals(Arrays.asList("java.lang.Object", "java.lang.Object"), getTypeNames(resolvedTypeParameters));
     }
 
     @Test
     public void testResolvingRawUsage2() throws NoSuchFieldException {
         final Type contextType = RawUsage.class.getField("rawStringKeyMap").getGenericType();
         final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(Map.class, contextType);
-        Assertions.assertEquals(Arrays.asList("java.lang.Object", "java.lang.Object"),
-                getTypeNames(resolvedTypeParameters));
+        assertEquals(Arrays.asList("java.lang.Object", "java.lang.Object"), getTypeNames(resolvedTypeParameters));
     }
 
     @SuppressWarnings("rawtypes")
@@ -183,8 +190,7 @@ public class GenericsResolverTest {
     public void testResolvingFixedDescendant() throws NoSuchFieldException {
         final Type contextType = StringMapDescendantUsage.class.getField("stringMapDescendant").getGenericType();
         final List<Type> resolvedTypeParameters = GenericsResolver.resolveBaseGenericVariables(Map.class, contextType);
-        Assertions.assertEquals(Arrays.asList("java.lang.String", "java.lang.String"),
-                getTypeNames(resolvedTypeParameters));
+        assertEquals(Arrays.asList("java.lang.String", "java.lang.String"), getTypeNames(resolvedTypeParameters));
     }
 
     static class StringMapDescendantUsage {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/GenericsTest.java
@@ -2,18 +2,19 @@ package cz.habarta.typescript.generator;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class GenericsTest {
 
+public class GenericsTest {
     @Test
     public void testAdvancedGenerics() throws Exception {
         final Settings settings = TestUtils.settings();
@@ -24,7 +25,8 @@ public class GenericsTest {
         new TypeScriptGenerator(settings).generateTypeScript(Input.from(A.class), Output.to(stringWriter));
         final String actual = stringWriter.toString().trim();
         final String nl = settings.newline;
-        final String expected = "export interface IA<U, V> {" + nl +
+        final String expected =
+                "export interface IA<U, V> {" + nl +
                 "    x: IA<string, string>;" + nl +
                 "    y: IA<IA<string, IB>, string[]>;" + nl +
                 "    z: IA<{ [index: string]: V }, number[]>;" + nl +
@@ -33,12 +35,9 @@ public class GenericsTest {
                 "export interface IB {" + nl +
                 "}";
         assertEquals(expected, actual);
-        assertEquals("IA<string, string>",
-                TestUtils.compileType(settings, A.class.getField("x").getGenericType()).toString());
-        assertEquals("IA<IA<string, IB>, string[]>",
-                TestUtils.compileType(settings, A.class.getField("y").getGenericType()).toString());
-        assertEquals("IA<{ [index: string]: V }, number[]>",
-                TestUtils.compileType(settings, A.class.getField("z").getGenericType()).toString());
+        assertEquals("IA<string, string>", TestUtils.compileType(settings, A.class.getField("x").getGenericType()).toString());
+        assertEquals("IA<IA<string, IB>, string[]>", TestUtils.compileType(settings, A.class.getField("y").getGenericType()).toString());
+        assertEquals("IA<{ [index: string]: V }, number[]>", TestUtils.compileType(settings, A.class.getField("z").getGenericType()).toString());
     }
 
     @Test
@@ -51,7 +50,8 @@ public class GenericsTest {
         new TypeScriptGenerator(settings).generateTypeScript(Input.from(C.class), Output.to(stringWriter));
         final String actual = stringWriter.toString().trim();
         final String nl = settings.newline;
-        final String expected = "export interface IC {" + nl +
+        final String expected =
+                "export interface IC {" + nl +
                 "    x: string[];" + nl +
                 "}";
         assertEquals(expected, actual);
@@ -67,7 +67,8 @@ public class GenericsTest {
         new TypeScriptGenerator(settings).generateTypeScript(Input.from(E.class), Output.to(stringWriter));
         final String actual = stringWriter.toString().trim();
         final String nl = settings.newline;
-        final String expected = "export interface D<T> {" + nl +
+        final String expected =
+                "export interface D<T> {" + nl +
                 "    x: T;" + nl +
                 "}" + nl +
                 "" + nl +
@@ -91,7 +92,8 @@ public class GenericsTest {
         new TypeScriptGenerator(settings).generateTypeScript(Input.from(IA.class), Output.to(stringWriter));
         final String actual = stringWriter.toString().trim();
         final String nl = settings.newline;
-        final String expected = "export interface IA extends IB<string> {" + nl +
+        final String expected =
+                "export interface IA extends IB<string> {" + nl +
                 "    type: string;" + nl +
                 "    x: string;" + nl +
                 "}" + nl +
@@ -107,9 +109,9 @@ public class GenericsTest {
     @Test
     public void testGenericsWithoutTypeArgument() {
         final Settings settings = TestUtils.settings();
-        final String output = new TypeScriptGenerator(settings)
-                .generateTypeScript(Input.from(Table.class, Page1.class, Page2.class));
-        final String expected = "interface Table<T> {\n" +
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Table.class, Page1.class, Page2.class));
+        final String expected =
+                "interface Table<T> {\n" +
                 "    rows: T[];\n" +
                 "}\n" +
                 "\n" +
@@ -127,7 +129,8 @@ public class GenericsTest {
     public void testGenericArray() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(TableGA.class));
-        final String expected = "interface TableGA<T> {\n" +
+        final String expected =
+                "interface TableGA<T> {\n" +
                 "    rows: T[];\n" +
                 "}";
         assertEquals(expected, output.trim());
@@ -137,7 +140,8 @@ public class GenericsTest {
     public void testArbitraryGenericParameter() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ExecutionResult.class));
-        final String expected = "interface ExecutionResult {\n" +
+        final String expected =
+                "interface ExecutionResult {\n" +
                 "    data: number;\n" +
                 "}";
         assertEquals(expected, output.trim());

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ImmutablesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ImmutablesTest.java
@@ -16,29 +16,31 @@ public class ImmutablesTest {
     public void testImmutables() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Shape.class));
-        final String expected = ("\n" +
-                "interface Shape {\n" +
-                "    kind: 'square' | 'rectangle' | 'circle';\n" +
-                "}\n" +
-                "\n" +
-                "interface Square extends Shape {\n" +
-                "    kind: 'square';\n" +
-                "    size: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface Rectangle extends Shape {\n" +
-                "    kind: 'rectangle';\n" +
-                "    width: number;\n" +
-                "    height: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface Circle extends Shape {\n" +
-                "    kind: 'circle';\n" +
-                "    radius: number;\n" +
-                "}\n" +
-                "\n" +
-                "type ShapeUnion = Square | Rectangle | Circle;\n" +
-                "").replace('\'', '"');
+        final String expected = (
+                """
+                        interface Shape {
+                            kind: 'square' | 'rectangle' | 'circle';
+                        }
+                        
+                        interface Square extends Shape {
+                            kind: 'square';
+                            size: number;
+                        }
+                        
+                        interface Rectangle extends Shape {
+                            kind: 'rectangle';
+                            width: number;
+                            height: number;
+                        }
+                        
+                        interface Circle extends Shape {
+                            kind: 'circle';
+                            radius: number;
+                        }
+                        
+                        type ShapeUnion = Square | Rectangle | Circle;
+                """
+                ).replace('\'', '"');
         Assertions.assertEquals(expected, output);
     }
 
@@ -61,7 +63,6 @@ public class ImmutablesTest {
     @JsonDeserialize(as = ImmutableRectangle.class)
     public static abstract class Rectangle implements Shape {
         public abstract double width();
-
         public abstract double height();
 
         public static Rectangle.Builder builder() {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/IncludeExcludePropertyTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/IncludeExcludePropertyTest.java
@@ -1,18 +1,18 @@
 
 package cz.habarta.typescript.generator;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 @SuppressWarnings("unused")
 public class IncludeExcludePropertyTest {
-
     public static Stream<JsonLibrary> data() {
         return Arrays.stream(JsonLibrary.values())
                 .filter(library -> library != JsonLibrary.jsonb);

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/InputTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/InputTest.java
@@ -3,16 +3,16 @@ package cz.habarta.typescript.generator;
 
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unused")
 public class InputTest {
-
     @Test
     public void testScanner() {
         final ScanResult scanResult = new ClassGraph().enableAllInfo().acceptPackages("cz.habarta").scan();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/InterfaceTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/InterfaceTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class InterfaceTest {
-
     @Test
     public void test() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ConfigurationResolvedTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ConfigurationResolvedTest.java
@@ -1,11 +1,11 @@
 package cz.habarta.typescript.generator;
 
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class Jackson2ConfigurationResolvedTest {
+import java.util.List;
 
+public class Jackson2ConfigurationResolvedTest {
     @Test
     public void test() {
         final Jackson2Configuration configuration = new Jackson2Configuration();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2ParserTest.java
@@ -15,6 +15,10 @@ import cz.habarta.typescript.generator.parser.BeanModel;
 import cz.habarta.typescript.generator.parser.EnumModel;
 import cz.habarta.typescript.generator.parser.Jackson2Parser;
 import cz.habarta.typescript.generator.parser.Model;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.bind.annotation.XmlElement;
 import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -22,16 +26,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
-import javax.xml.bind.annotation.XmlElement;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
 @SuppressWarnings("unused")
 public class Jackson2ParserTest {
-
     @Test
     public void test() {
         final Jackson2Parser jacksonParser = getJackson2Parser();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2PolymorphismTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Jackson2PolymorphismTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class Jackson2PolymorphismTest {
-
     @Test
     public void testPropertyNameQuoting() {
         final String output = new TypeScriptGenerator(TestUtils.settings())

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JavadocTest.java
@@ -3,13 +3,13 @@ package cz.habarta.typescript.generator;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import cz.habarta.typescript.generator.parser.*;
-import java.io.File;
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class JavadocTest {
+import java.io.File;
+import java.util.List;
 
+public class JavadocTest {
     @Test
     public void testJavadoc() {
         final Settings settings = TestUtils.settings();
@@ -58,35 +58,35 @@ public class JavadocTest {
             Assertions.assertTrue(generated.contains("0000ff"));
         }
         {
-            final String generated = new TypeScriptGenerator(settings)
-                    .generateTypeScript(Input.from(DeprecatedClassWithoutJavadoc.class));
-            final String expected = ""
-                    + "/**\n"
-                    + " * @deprecated\n"
-                    + " */\n"
-                    + "interface DeprecatedClassWithoutJavadoc {\n"
-                    + "    /**\n"
-                    + "     * @deprecated\n"
-                    + "     */\n"
-                    + "    deprecatedField: string;\n"
-                    + "}";
+            final String generated = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DeprecatedClassWithoutJavadoc.class));
+            final String expected = """
+                    \
+                    /**
+                     * @deprecated
+                     */
+                    interface DeprecatedClassWithoutJavadoc {
+                        /**
+                         * @deprecated
+                         */
+                        deprecatedField: string;
+                    }""";
             Assertions.assertEquals(expected.trim(), generated.trim());
         }
         {
-            final String generated = new TypeScriptGenerator(settings)
-                    .generateTypeScript(Input.from(DeprecatedEnumWithoutJavadoc.class));
-            final String expected = ""
-                    + "/**\n"
-                    + " * @deprecated\n"
-                    + " * \n"
-                    + " * Values:\n"
-                    + " * - `North`\n"
-                    + " * - `East` - @deprecated\n"
-                    + " * - `South`\n"
-                    + " * - `West`\n"
-                    + " */\n"
-                    + "type DeprecatedEnumWithoutJavadoc = \"North\" | \"East\" | \"South\" | \"West\";\n"
-                    + "";
+            final String generated = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DeprecatedEnumWithoutJavadoc.class));
+            final String expected = """
+                    \
+                    /**
+                     * @deprecated
+                     *\s
+                     * Values:
+                     * - `North`
+                     * - `East` - @deprecated
+                     * - `South`
+                     * - `West`
+                     */
+                    type DeprecatedEnumWithoutJavadoc = "North" | "East" | "South" | "West";
+                    """;
             Assertions.assertEquals(expected.trim(), generated.trim());
         }
         {
@@ -171,8 +171,7 @@ public class JavadocTest {
     public enum DeprecatedEnumWithoutJavadoc {
 
         North,
-        @Deprecated
-        East,
+        @Deprecated East,
         South,
         West
 
@@ -208,10 +207,10 @@ public class JavadocTest {
 
     /**
      * First sentence.
-     * 
+     *
      * <p> Long
      * paragraph </p>
-     * 
+     *
      * <p>Second
      * paragraph</p>
      */

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxbTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxbTest.java
@@ -1,16 +1,16 @@
 
 package cz.habarta.typescript.generator;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementRef;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 public class JaxbTest {
-
     @Test
     public void test() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxbV3Test.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxbV3Test.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class JaxbV3Test {
-
     @Test
     public void test() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxrsV2ApplicationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JaxrsV2ApplicationTest.java
@@ -14,10 +14,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import jakarta.ws.rs.*;
-import jakarta.ws.rs.container.AsyncResponse;
-import jakarta.ws.rs.container.Suspended;
-import jakarta.ws.rs.core.*;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.jdkhttp.JdkHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -25,6 +21,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.activation.DataSource;
+import javax.ws.rs.*;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.*;
 import javax.xml.bind.JAXBElement;
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
@@ -37,7 +37,7 @@ import java.util.*;
 import java.util.function.Predicate;
 
 @SuppressWarnings("unused")
-public class JaxrsApplicationTest {
+public class JaxrsV2ApplicationTest {
     @Test
     public void testReturnedTypesFromApplication() {
         final List<SourceType<Type>> sourceTypes = JaxrsApplicationScanner.scanJaxrsApplication(TestApplication.class,

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JsonDeserializationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JsonDeserializationTest.java
@@ -8,6 +8,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.habarta.typescript.generator.ext.AxiosClientExtension;
 import cz.habarta.typescript.generator.ext.JsonDeserializationExtension;
 import cz.habarta.typescript.generator.util.Utils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -15,13 +19,9 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unused")
 public class JsonDeserializationTest {
-
     @Test
     public void test() throws IOException {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JsonUnwrappedTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JsonUnwrappedTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class JsonUnwrappedTest {
-
     @Test
     public void test() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JsonViewTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/JsonViewTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class JsonViewTest {
-
     public static void main(String[] args) throws Exception {
         final SomeClass parent1 = new SomeClass();
         parent1.id = 22;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/MapEntryTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/MapEntryTest.java
@@ -4,13 +4,13 @@ package cz.habarta.typescript.generator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.habarta.typescript.generator.util.Utils;
-import java.io.Serializable;
-import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class MapEntryTest {
+import java.io.Serializable;
+import java.util.*;
 
+public class MapEntryTest {
     public static class ClassWithEntries {
         public String name = "ClassWithEntries";
         public Entry1<MyBean, String> entry1 = new Entry1<>(new MyBean("nnn"), "NNN");

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/MapExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/MapExtensionTest.java
@@ -1,15 +1,15 @@
 package cz.habarta.typescript.generator;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MapExtensionTest {
-
     @Test
     public void testOrder1() {
         final Settings settings = TestUtils.settings();
@@ -40,8 +40,7 @@ public class MapExtensionTest {
         public MapExtension<String> mapExt;
     }
 
-    public static class MapExtension<T> extends HashMap<T, Long> {
-    }
+    public static class MapExtension<T> extends HashMap<T, Long> {}
 
     @Test
     public void testStringList() {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/MapTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/MapTest.java
@@ -1,12 +1,12 @@
 
 package cz.habarta.typescript.generator;
 
-import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class MapTest {
+import java.util.Map;
 
+public class MapTest {
     public static class ClassWithMap {
         public Map<String, Person> people;
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModelCompilerTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModelCompilerTest.java
@@ -6,17 +6,17 @@ import cz.habarta.typescript.generator.compiler.ModelCompiler;
 import cz.habarta.typescript.generator.emitter.TsModel;
 import cz.habarta.typescript.generator.parser.Jackson2Parser;
 import cz.habarta.typescript.generator.parser.Model;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unused")
 public class ModelCompilerTest {
-
     @Test
     public void testEnum() throws Exception {
         final Settings settings = getTestSettings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModelParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModelParserTest.java
@@ -5,20 +5,19 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import cz.habarta.typescript.generator.parser.Jackson2Parser;
 import cz.habarta.typescript.generator.parser.Model;
 import cz.habarta.typescript.generator.parser.ModelParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 public class ModelParserTest {
-
     @Test
     public void testClassDiscovery1() {
         final Model model = parseModel(RootClass1.class);
         Assertions.assertEquals(2, model.getBeans().size());
-
     }
 
     @Test

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModuleDependenciesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ModuleDependenciesTest.java
@@ -3,17 +3,17 @@ package cz.habarta.typescript.generator;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unused")
 public class ModuleDependenciesTest {
-
     @Test
     public void test() {
         generateModuleA();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NamingTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NamingTest.java
@@ -3,14 +3,14 @@ package cz.habarta.typescript.generator;
 
 import cz.habarta.typescript.generator.compiler.SymbolTable;
 import cz.habarta.typescript.generator.yield.KeywordInPackage;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+
 @SuppressWarnings("unused")
 public class NamingTest {
-
     @Test
     public void testConflictReport() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NullabilityTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NullabilityTest.java
@@ -1,15 +1,15 @@
 
 package cz.habarta.typescript.generator;
 
-import java.util.Date;
-import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Date;
+import java.util.List;
+
 @SuppressWarnings("unused")
 public class NullabilityTest {
-
     @Test
     public void test() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NumberEnumTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/NumberEnumTest.java
@@ -7,17 +7,17 @@ import cz.habarta.typescript.generator.compiler.EnumKind;
 import cz.habarta.typescript.generator.parser.EnumModel;
 import cz.habarta.typescript.generator.parser.Model;
 import cz.habarta.typescript.generator.parser.ModelParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 public class NumberEnumTest {
-
     @Test
     public void testParser() {
         final Settings settings = TestUtils.settings();
@@ -36,10 +36,11 @@ public class NumberEnumTest {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SomeCode.class));
         Assertions.assertEquals(
-                "declare const enum SomeCode {\n" +
-                        "    VALUE0 = 10,\n" +
-                        "    VALUE1 = 11,\n" +
-                        "}",
+                """
+                        declare const enum SomeCode {
+                            VALUE0 = 10,
+                            VALUE1 = 11,
+                        }""",
                 output.trim());
     }
 
@@ -50,10 +51,11 @@ public class NumberEnumTest {
         settings.nonConstEnums = true;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SomeCode.class));
         Assertions.assertEquals(
-                "enum SomeCode {\n" +
-                        "    VALUE0 = 10,\n" +
-                        "    VALUE1 = 11,\n" +
-                        "}",
+                """
+                        enum SomeCode {
+                            VALUE0 = 10,
+                            VALUE1 = 11,
+                        }""",
                 output.trim());
     }
 
@@ -64,10 +66,11 @@ public class NumberEnumTest {
         settings.nonConstEnumAnnotations.add(SomeNonConstAnnotation.class);
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(SomeCode.class));
         Assertions.assertEquals(
-                "enum SomeCode {\n" +
-                        "    VALUE0 = 10,\n" +
-                        "    VALUE1 = 11,\n" +
-                        "}",
+                """
+                        enum SomeCode {
+                            VALUE0 = 10,
+                            VALUE1 = 11,
+                        }""",
                 output.trim());
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ObjectAsIdTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ObjectAsIdTest.java
@@ -9,20 +9,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import cz.habarta.typescript.generator.util.Utils;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 @SuppressWarnings("unused")
 public class ObjectAsIdTest {
-
     @Test
     public void testJackson() throws JsonProcessingException {
         final TestObjectA testObjectA = new TestObjectA();
@@ -114,10 +110,9 @@ public class ObjectAsIdTest {
         return Stream.of(values).collect(Collectors.toMap(
                 v -> "k" + index.incrementAndGet(),
                 v -> v,
-                (v1, v2) -> {
-                    throw new RuntimeException();
-                },
-                LinkedHashMap::new));
+                (v1, v2) -> { throw new RuntimeException(); },
+                LinkedHashMap::new
+        ));
     }
 
     @Test

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalAnnotationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalAnnotationTest.java
@@ -2,16 +2,16 @@ package cz.habarta.typescript.generator;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import cz.habarta.typescript.generator.parser.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.*;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 public class OptionalAnnotationTest {
-
     @Test
     public void testJackson2OptionalAnnotation() {
         Settings settings = new Settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/OptionalTest.java
@@ -4,15 +4,15 @@ package cz.habarta.typescript.generator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.OptionalInt;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+
 @SuppressWarnings("unused")
 public class OptionalTest {
-
     @Test
     public void test() {
         final String output = new TypeScriptGenerator(TestUtils.settings())
@@ -53,56 +53,61 @@ public class OptionalTest {
     @Test
     public void testDeclarationQuestionMark() {
         testDeclaration(OptionalPropertiesDeclaration.questionMark,
-                """
-                        interface Person {
-                            name: string;
-                            email?: string;
-                            age?: number;
-                        }""");
+                        """
+                                interface Person {
+                                    name: string;
+                                    email?: string;
+                                    age?: number;
+                                }"""
+        );
     }
 
     @Test
     public void testDeclarationNullableType() {
         testDeclaration(OptionalPropertiesDeclaration.nullableType,
-                """
-                        interface Person {
-                            name: string;
-                            email: string | null;
-                            age: number | null;
-                        }""");
+                        """
+                                interface Person {
+                                    name: string;
+                                    email: string | null;
+                                    age: number | null;
+                                }"""
+        );
     }
 
     @Test
     public void testDeclarationQuestionMarkAndNullableType() {
         testDeclaration(OptionalPropertiesDeclaration.questionMarkAndNullableType,
-                """
-                        interface Person {
-                            name: string;
-                            email?: string | null;
-                            age?: number | null;
-                        }""");
+                        """
+                                interface Person {
+                                    name: string;
+                                    email?: string | null;
+                                    age?: number | null;
+                                }"""
+        );
     }
 
     @Test
     public void testDeclarationNullableAndUndefinableType() {
         testDeclaration(OptionalPropertiesDeclaration.nullableAndUndefinableType,
-                """
-                        interface Person {
-                            name: string;
-                            email: string | null | undefined;
-                            age: number | null | undefined;
-                        }""");
+                        """
+                                interface Person {
+                                    name: string;
+                                    email: string | null | undefined;
+                                    age: number | null | undefined;
+                                }"""
+        );
     }
 
     @Test
     public void testDeclarationUndefinableType() {
         testDeclaration(OptionalPropertiesDeclaration.undefinableType,
-                """
-                        interface Person {
-                            name: string;
-                            email: string | undefined;
-                            age: number | undefined;
-                        }""");
+                        """
+                                interface Person {
+                                    name: string;
+                                    email: string | undefined;
+                                    age: number | undefined;
+                                }"""
+        );
     }
 
     private static void testDeclaration(OptionalPropertiesDeclaration declaration, String expected) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/PathTemplateTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/PathTemplateTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PathTemplateTest {
-
     @Test
     public void test() {
         Assertions.assertEquals(0, PathTemplate.parse("").getParts().size());

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Person.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Person.java
@@ -5,11 +5,9 @@ import java.util.List;
 import java.util.Map;
 
 public class Person {
-
     public String name;
     public int age;
     public boolean hasChildren;
     public List<String> tags;
     public Map<String, String> emails;
-
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/PersonTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/PersonTest.java
@@ -1,11 +1,11 @@
 
 package cz.habarta.typescript.generator;
 
-import java.io.File;
 import org.junit.jupiter.api.Test;
 
-public class PersonTest {
+import java.io.File;
 
+public class PersonTest {
     @Test
     public void test() {
         new TypeScriptGenerator(TestUtils.settings()).generateTypeScript(Input.from(Person.class),

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ReadOnlyWriteOnlyTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ReadOnlyWriteOnlyTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ReadOnlyWriteOnlyTest {
-
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ReadOnlyWriteOnlyUser {
 
@@ -71,28 +70,29 @@ public class ReadOnlyWriteOnlyTest {
     public void test() {
         final Settings settings = TestUtils.settings();
         settings.generateReadonlyAndWriteonlyJSDocTags = true;
-        final String output = new TypeScriptGenerator(settings)
-                .generateTypeScript(Input.from(ReadOnlyWriteOnlyUser.class));
-        final String expected = "\n"
-                + "interface ReadOnlyWriteOnlyUser {\n"
-                + "    name: string;\n"
-                + "    /**\n"
-                + "     * @readonly\n"
-                + "     */\n"
-                + "    id1: string;\n"
-                + "    /**\n"
-                + "     * @writeonly\n"
-                + "     */\n"
-                + "    password1: string;\n"
-                + "    /**\n"
-                + "     * @readonly\n"
-                + "     */\n"
-                + "    id2: string;\n"
-                + "    /**\n"
-                + "     * @writeonly\n"
-                + "     */\n"
-                + "    password2: string;\n"
-                + "}\n";
+        final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(ReadOnlyWriteOnlyUser.class));
+        final String expected = """
+                
+                interface ReadOnlyWriteOnlyUser {
+                    name: string;
+                    /**
+                     * @readonly
+                     */
+                    id1: string;
+                    /**
+                     * @writeonly
+                     */
+                    password1: string;
+                    /**
+                     * @readonly
+                     */
+                    id2: string;
+                    /**
+                     * @writeonly
+                     */
+                    password2: string;
+                }
+                """;
         Assertions.assertEquals(expected, output);
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SettingsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SettingsTest.java
@@ -1,18 +1,77 @@
 
 package cz.habarta.typescript.generator;
 
-import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class SettingsTest {
+    /**
+     * Checks if the method can load a class from a given class name,
+     * either it has a generic type argument or not.
+     */
+    @Test
+    void testLoadPrimitiveOrRegularClass() {
+        // A map where each key is a type reference (class/interface) and each value is a list of class names representing that type
+        final var typeToClassName = Map.of(
+            List.class, List.of("java.util.List", "java.util.List<String>", "java.util.List<java.util.List<String>>"),
+            Map.class, List.of("java.util.Map", "java.util.Map<Integer, String>", "java.util.Map<Integer, java.util.List<String>>")
+        );
+
+        typeToClassName.forEach((type, classNameList) -> {
+            classNameList.forEach(className -> assertTypeLoadedFromClassName(className, type));
+        });
+    }
+
+    /**
+     * Asserts that a class is loaded from a given class name.
+     * @param className name of the class to load (that may contain generic arguments, even nested ones)
+     * @param expectedClass the class that sould be loaded from the given class name
+     */
+    private void assertTypeLoadedFromClassName(final String className, final Class<?> expectedClass) {
+        try {
+            final var loadedClass = Settings.loadPrimitiveOrRegularClass(getClass().getClassLoader(), className);
+            assertEquals(expectedClass, loadedClass);
+        } catch (ClassNotFoundException e) {
+            Assertions.fail(e);
+        }
+    }
+
+    /**
+     * Checks if generic type arguments are parsed correctly, even when there are nested generic types.
+     */
+    @Test
+    void testParseGenericName() {
+        final var className = "Class";
+        final String[] nonNestedGenericArgumentTypes = {"T1", "T2"};
+
+        assertEquals(newGenericName(className, nonNestedGenericArgumentTypes), Settings.parseGenericName("Class<T1, T2>"));
+        assertEquals(newGenericName(className, nonNestedGenericArgumentTypes), Settings.parseGenericName("Class[T1, T2]"));
+        assertEquals(newGenericName(className, "T1[T2]", "T3"), Settings.parseGenericName("Class[T1[T2], T3]"));
+        assertEquals(newGenericName(className, "T1<T2>", "T3"), Settings.parseGenericName("Class<T1<T2>, T3>"));
+    }
+
+    /**
+     * Creates a new {@link Settings.GenericName} instance.
+     * @param className name of a class that have generic type arguments.
+     * @param genericArguments generic type arguments
+     * @return a new {@link Settings.GenericName} instance.
+     */
+    private static Settings.GenericName newGenericName(final String className, final String ...genericArguments) {
+        return new Settings.GenericName(className, Arrays.asList(genericArguments));
+    }
 
     @Test
     public void testParseModifiers() {
-        Assertions.assertEquals(0, Settings.parseModifiers("", Modifier.fieldModifiers()));
-        Assertions.assertEquals(Modifier.STATIC, Settings.parseModifiers("static", Modifier.fieldModifiers()));
-        Assertions.assertEquals(Modifier.STATIC | Modifier.TRANSIENT,
-                Settings.parseModifiers("static | transient", Modifier.fieldModifiers()));
+        assertEquals(0, Settings.parseModifiers("", Modifier.fieldModifiers()));
+        assertEquals(Modifier.STATIC, Settings.parseModifiers("static", Modifier.fieldModifiers()));
+        assertEquals(Modifier.STATIC | Modifier.TRANSIENT, Settings.parseModifiers("static | transient", Modifier.fieldModifiers()));
     }
 
     @Test

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SortedTypesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SortedTypesTest.java
@@ -20,16 +20,16 @@ public class SortedTypesTest {
         final Settings settings = TestUtils.settings();
         settings.sortDeclarations = true;
         String expected = "" +
-                "" + settings.newline +
-                "interface A {" + settings.newline +
-                "    x: number;" + settings.newline +
-                "    yyy: number;" + settings.newline +
-                "}" + settings.newline +
-                "" + settings.newline +
-                "interface B {" + settings.newline +
-                "    x: number;" + settings.newline +
-                "}" + settings.newline +
-                "";
+""                           + settings.newline +
+"interface A {"              + settings.newline +
+"    x: number;"             + settings.newline +
+"    yyy: number;"           + settings.newline +
+"}"                          + settings.newline +
+""                           + settings.newline +
+"interface B {"              + settings.newline +
+"    x: number;"             + settings.newline +
+"}"                          + settings.newline +
+"";
         final String actual = new TypeScriptGenerator(settings).generateTypeScript(Input.from(classes));
 
         assertEquals(expected, actual);

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/StyleConfigurationTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/StyleConfigurationTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class StyleConfigurationTest {
-
     public static class A {
         public int getX() {
             return -1;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Swagger3Test.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/Swagger3Test.java
@@ -6,18 +6,18 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 public class Swagger3Test {
-
     @Test
     public void test() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SwaggerTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/SwaggerTest.java
@@ -2,15 +2,16 @@
 package cz.habarta.typescript.generator;
 
 import io.swagger.annotations.*;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 public class SwaggerTest {
 
@@ -131,7 +132,7 @@ public class SwaggerTest {
     private static class DocumentedApplication extends Application {
         @Override
         public Set<Class<?>> getClasses() {
-            return new LinkedHashSet<>(List.<Class<?>>of(DocumentedResource.class));
+            return new LinkedHashSet<>(List.of(DocumentedResource.class));
         }
     }
 

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TaggedUnionsTest.java
@@ -6,11 +6,12 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.List;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unused")
 public class TaggedUnionsTest {
@@ -186,33 +187,36 @@ public class TaggedUnionsTest {
     public void testTaggedUnions() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Geometry.class));
-        final String expected = ("\n" +
-                "interface Geometry {\n" +
-                "    shapes: ShapeUnion[];\n" +
-                "}\n" +
-                "\n" +
-                "interface Shape {\n" +
-                "    kind: 'square' | 'rectangle' | 'circle';\n" +
-                "}\n" +
-                "\n" +
-                "interface Square extends Shape {\n" +
-                "    kind: 'square';\n" +
-                "    size: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface Rectangle extends Shape {\n" +
-                "    kind: 'rectangle';\n" +
-                "    width: number;\n" +
-                "    height: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface Circle extends Shape {\n" +
-                "    kind: 'circle';\n" +
-                "    radius: number;\n" +
-                "}\n" +
-                "\n" +
-                "type ShapeUnion = Square | Rectangle | Circle;\n" +
-                "").replace('\'', '"');
+        final String expected = (
+                """
+                        
+                        interface Geometry {
+                            shapes: ShapeUnion[];
+                        }
+                        
+                        interface Shape {
+                            kind: 'square' | 'rectangle' | 'circle';
+                        }
+                        
+                        interface Square extends Shape {
+                            kind: 'square';
+                            size: number;
+                        }
+                        
+                        interface Rectangle extends Shape {
+                            kind: 'rectangle';
+                            width: number;
+                            height: number;
+                        }
+                        
+                        interface Circle extends Shape {
+                            kind: 'circle';
+                            radius: number;
+                        }
+                        
+                        type ShapeUnion = Square | Rectangle | Circle;
+                        """
+                ).replace('\'', '"');
         Assertions.assertEquals(expected, output);
     }
 
@@ -220,33 +224,36 @@ public class TaggedUnionsTest {
     public void testTaggedUnionsWithInterfaces() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(IShape2.class));
-        final String expected = ("\n" +
-                "interface IShape2 {\n" +
-                "    kind: 'circle' | 'square' | 'rectangle';\n" +
-                "}\n" +
-                "\n" +
-                "interface CSquare2 extends IQuadrilateral2 {\n" +
-                "    kind: 'square';\n" +
-                "    size: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface CRectangle2 extends IQuadrilateral2 {\n" +
-                "    kind: 'rectangle';\n" +
-                "    width: number;\n" +
-                "    height: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface CCircle2 extends IShape2 {\n" +
-                "    kind: 'circle';\n" +
-                "    radius: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface IQuadrilateral2 extends IShape2 {\n" +
-                "    kind: 'square' | 'rectangle';\n" +
-                "}\n" +
-                "\n" +
-                "type IShape2Union = CSquare2 | CRectangle2 | CCircle2;\n" +
-                "").replace('\'', '"');
+        final String expected = (
+                """
+                        
+                        interface IShape2 {
+                            kind: 'circle' | 'square' | 'rectangle';
+                        }
+                        
+                        interface CSquare2 extends IQuadrilateral2 {
+                            kind: 'square';
+                            size: number;
+                        }
+                        
+                        interface CRectangle2 extends IQuadrilateral2 {
+                            kind: 'rectangle';
+                            width: number;
+                            height: number;
+                        }
+                        
+                        interface CCircle2 extends IShape2 {
+                            kind: 'circle';
+                            radius: number;
+                        }
+                        
+                        interface IQuadrilateral2 extends IShape2 {
+                            kind: 'square' | 'rectangle';
+                        }
+                        
+                        type IShape2Union = CSquare2 | CRectangle2 | CCircle2;
+                        """
+                ).replace('\'', '"');
         Assertions.assertEquals(expected, output);
     }
 
@@ -254,33 +261,37 @@ public class TaggedUnionsTest {
     public void testTaggedUnionsWithOverlappingInterfaces() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(IShape3.class));
-        final String expected = ("\n" +
-                "interface IShape3 {\n" +
-                "    kind: 'circle' | 'rectangle';\n" +
-                "}\n" +
-                "\n" +
-                "interface IRectangle3 extends INamedQuadrilateral3 {\n" +
-                "    kind: 'rectangle';\n" +
-                "}\n" +
-                "\n" +
-                "interface ICircle3 extends INamedShape3 {\n" +
-                "    kind: 'circle';\n" +
-                "}\n" +
-                "\n" +
-                "interface INamedQuadrilateral3 extends INamedShape3, IQuadrilateral3 {\n" +
-                "    kind: 'rectangle';\n" +
-                "}\n" +
-                "\n" +
-                "interface INamedShape3 extends IShape3 {\n" +
-                "    kind: 'circle' | 'rectangle';\n" +
-                "    name: string;\n" +
-                "}\n" +
-                "\n" +
-                "interface IQuadrilateral3 extends IShape3 {\n" +
-                "    kind: 'rectangle';\n" +
-                "}\n" +
-                "\n" +
-                "type IShape3Union = IRectangle3 | ICircle3;\n").replace('\'', '"');
+        final String expected = (
+                """
+                        
+                        interface IShape3 {
+                            kind: 'circle' | 'rectangle';
+                        }
+                        
+                        interface IRectangle3 extends INamedQuadrilateral3 {
+                            kind: 'rectangle';
+                        }
+                        
+                        interface ICircle3 extends INamedShape3 {
+                            kind: 'circle';
+                        }
+                        
+                        interface INamedQuadrilateral3 extends INamedShape3, IQuadrilateral3 {
+                            kind: 'rectangle';
+                        }
+                        
+                        interface INamedShape3 extends IShape3 {
+                            kind: 'circle' | 'rectangle';
+                            name: string;
+                        }
+                        
+                        interface IQuadrilateral3 extends IShape3 {
+                            kind: 'rectangle';
+                        }
+                        
+                        type IShape3Union = IRectangle3 | ICircle3;
+                        """
+                ).replace('\'', '"');
         Assertions.assertEquals(expected, output);
     }
 
@@ -289,31 +300,34 @@ public class TaggedUnionsTest {
         final Settings settings = TestUtils.settings();
         settings.disableTaggedUnions = true;
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Geometry.class));
-        final String expected = ("\n" +
-                "interface Geometry {\n" +
-                "    shapes: Shape[];\n" +
-                "}\n" +
-                "\n" +
-                "interface Shape {\n" +
-                "    kind: 'square' | 'rectangle' | 'circle';\n" +
-                "}\n" +
-                "\n" +
-                "interface Square extends Shape {\n" +
-                "    kind: 'square';\n" +
-                "    size: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface Rectangle extends Shape {\n" +
-                "    kind: 'rectangle';\n" +
-                "    width: number;\n" +
-                "    height: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface Circle extends Shape {\n" +
-                "    kind: 'circle';\n" +
-                "    radius: number;\n" +
-                "}\n" +
-                "").replace('\'', '"');
+        final String expected = (
+                """
+                        
+                        interface Geometry {
+                            shapes: Shape[];
+                        }
+                        
+                        interface Shape {
+                            kind: 'square' | 'rectangle' | 'circle';
+                        }
+                        
+                        interface Square extends Shape {
+                            kind: 'square';
+                            size: number;
+                        }
+                        
+                        interface Rectangle extends Shape {
+                            kind: 'rectangle';
+                            width: number;
+                            height: number;
+                        }
+                        
+                        interface Circle extends Shape {
+                            kind: 'circle';
+                            radius: number;
+                        }
+                        """
+                ).replace('\'', '"');
         Assertions.assertEquals(expected, output);
     }
 
@@ -321,29 +335,32 @@ public class TaggedUnionsTest {
     public void testTaggedUnionsWithDiamond() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(DiamondA.class));
-        final String expected = ("\n" +
-                "interface DiamondA {\n" +
-                "    kind: 'b1' | 'c' | 'b2';\n" +
-                "    a: string;\n" +
-                "}\n" +
-                "\n" +
-                "interface DiamondB1 extends DiamondA {\n" +
-                "    kind: 'b1' | 'c';\n" +
-                "    b1: string;\n" +
-                "}\n" +
-                "\n" +
-                "interface DiamondB2 extends DiamondA {\n" +
-                "    kind: 'b2' | 'c';\n" +
-                "    b2: string;\n" +
-                "}\n" +
-                "\n" +
-                "interface DiamondC extends DiamondB1, DiamondB2 {\n" +
-                "    kind: 'c';\n" +
-                "    c: string;\n" +
-                "}\n" +
-                "\n" +
-                "type DiamondAUnion = DiamondB1 | DiamondB2 | DiamondC;\n" +
-                "").replace('\'', '"');
+        final String expected = (
+                """
+                        
+                        interface DiamondA {
+                            kind: 'b1' | 'c' | 'b2';
+                            a: string;
+                        }
+                        
+                        interface DiamondB1 extends DiamondA {
+                            kind: 'b1' | 'c';
+                            b1: string;
+                        }
+                        
+                        interface DiamondB2 extends DiamondA {
+                            kind: 'b2' | 'c';
+                            b2: string;
+                        }
+                        
+                        interface DiamondC extends DiamondB1, DiamondB2 {
+                            kind: 'c';
+                            c: string;
+                        }
+                        
+                        type DiamondAUnion = DiamondB1 | DiamondB2 | DiamondC;
+                        """
+                ).replace('\'', '"');
         Assertions.assertEquals(expected, output);
     }
 
@@ -351,25 +368,27 @@ public class TaggedUnionsTest {
     public void testIdClass() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Car.class));
-        final String expected = ("\n" +
-                "interface Car {\n" +
-                "    '@class': 'cz.habarta.typescript.generator.TaggedUnionsTest$DieselCar' | 'cz.habarta.typescript.generator.TaggedUnionsTest$ElectricCar';\n"
-                +
-                "    name: string;\n" +
-                "}\n" +
-                "\n" +
-                "interface DieselCar extends Car {\n" +
-                "    '@class': 'cz.habarta.typescript.generator.TaggedUnionsTest$DieselCar';\n" +
-                "    fuelTankCapacityInLiters: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface ElectricCar extends Car {\n" +
-                "    '@class': 'cz.habarta.typescript.generator.TaggedUnionsTest$ElectricCar';\n" +
-                "    batteryCapacityInKWh: number;\n" +
-                "}\n" +
-                "\n" +
-                "type CarUnion = DieselCar | ElectricCar;\n" +
-                "").replace('\'', '"');
+        final String expected = (
+                """
+                        
+                        interface Car {
+                            '@class': 'cz.habarta.typescript.generator.TaggedUnionsTest$DieselCar' | 'cz.habarta.typescript.generator.TaggedUnionsTest$ElectricCar';
+                            name: string;
+                        }
+                        
+                        interface DieselCar extends Car {
+                            '@class': 'cz.habarta.typescript.generator.TaggedUnionsTest$DieselCar';
+                            fuelTankCapacityInLiters: number;
+                        }
+                        
+                        interface ElectricCar extends Car {
+                            '@class': 'cz.habarta.typescript.generator.TaggedUnionsTest$ElectricCar';
+                            batteryCapacityInKWh: number;
+                        }
+                        
+                        type CarUnion = DieselCar | ElectricCar;
+                        """
+                ).replace('\'', '"');
         Assertions.assertEquals(expected, output);
     }
 
@@ -489,33 +508,36 @@ public class TaggedUnionsTest {
     public void testTaggedUnionsWithExistingProperty() {
         final Settings settings = TestUtils.settings();
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Geometry2.class));
-        final String expected = ("\n" +
-                "interface Geometry2 {\n" +
-                "    shapes: Shape2Union[];\n" +
-                "}\n" +
-                "\n" +
-                "interface Shape2 {\n" +
-                "    kind: 'square' | 'rectangle' | 'circle';\n" +
-                "}\n" +
-                "\n" +
-                "interface Square2 extends Shape2 {\n" +
-                "    kind: 'square';\n" +
-                "    size: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface Rectangle2 extends Shape2 {\n" +
-                "    kind: 'rectangle';\n" +
-                "    width: number;\n" +
-                "    height: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface Circle2 extends Shape2 {\n" +
-                "    kind: 'circle';\n" +
-                "    radius: number;\n" +
-                "}\n" +
-                "\n" +
-                "type Shape2Union = Square2 | Rectangle2 | Circle2;\n" +
-                "").replace('\'', '"');
+        final String expected = (
+                """
+                        
+                        interface Geometry2 {
+                            shapes: Shape2Union[];
+                        }
+                        
+                        interface Shape2 {
+                            kind: 'square' | 'rectangle' | 'circle';
+                        }
+                        
+                        interface Square2 extends Shape2 {
+                            kind: 'square';
+                            size: number;
+                        }
+                        
+                        interface Rectangle2 extends Shape2 {
+                            kind: 'rectangle';
+                            width: number;
+                            height: number;
+                        }
+                        
+                        interface Circle2 extends Shape2 {
+                            kind: 'circle';
+                            radius: number;
+                        }
+                        
+                        type Shape2Union = Square2 | Rectangle2 | Circle2;
+                        """
+                ).replace('\'', '"');
         Assertions.assertEquals(expected, output);
     }
 
@@ -524,28 +546,31 @@ public class TaggedUnionsTest {
         final Settings settings = TestUtils.settings();
         settings.disableTaggedUnionAnnotations = List.of(TestMarker.class);
         final String output = new TypeScriptGenerator(settings).generateTypeScript(Input.from(Geometry2.class));
-        final String expected = ("\n" +
-                "interface Geometry2 {\n" +
-                "    shapes: Shape2[];\n" +
-                "}\n" +
-                "\n" +
-                "interface Shape2 {\n" +
-                "    kind: string;\n" +
-                "}\n" +
-                "\n" +
-                "interface Square2 extends Shape2 {\n" +
-                "    size: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface Rectangle2 extends Shape2 {\n" +
-                "    width: number;\n" +
-                "    height: number;\n" +
-                "}\n" +
-                "\n" +
-                "interface Circle2 extends Shape2 {\n" +
-                "    radius: number;\n" +
-                "}\n" +
-                "").replace('\'', '"');
+        final String expected = (
+                """
+                        
+                        interface Geometry2 {
+                            shapes: Shape2[];
+                        }
+                        
+                        interface Shape2 {
+                            kind: string;
+                        }
+                        
+                        interface Square2 extends Shape2 {
+                            size: number;
+                        }
+                        
+                        interface Rectangle2 extends Shape2 {
+                            width: number;
+                            height: number;
+                        }
+                        
+                        interface Circle2 extends Shape2 {
+                            radius: number;
+                        }
+                        """
+                );
         Assertions.assertEquals(expected, output);
     }
 
@@ -604,34 +629,25 @@ public class TaggedUnionsTest {
             @JsonSubTypes.Type(value = FormRecord.class),
             @JsonSubTypes.Type(value = ListRecord.class),
     })
-    static abstract class Record {
-    }
+
+    static abstract class Record {}
 
     @JsonSubTypes({
-            @JsonSubTypes.Type(value = OrderFormRecord.class, name = "order.form"),
-            @JsonSubTypes.Type(value = ProductFormRecord.class, name = "product.form"),
+        @JsonSubTypes.Type(value = OrderFormRecord.class, name = "order.form"),
+        @JsonSubTypes.Type(value = ProductFormRecord.class, name = "product.form"),
     })
-    static abstract class FormRecord extends Record {
-    }
+    static abstract class FormRecord extends Record {}
 
     @JsonSubTypes({
-            @JsonSubTypes.Type(value = OrderListRecord.class, name = "order.list"),
-            @JsonSubTypes.Type(value = ProductListRecord.class, name = "product.list"),
+        @JsonSubTypes.Type(value = OrderListRecord.class, name = "order.list"),
+        @JsonSubTypes.Type(value = ProductListRecord.class, name = "product.list"),
     })
-    static abstract class ListRecord extends Record {
-    }
+    static abstract class ListRecord extends Record {}
 
-    static class OrderFormRecord extends FormRecord {
-    }
-
-    static class OrderListRecord extends ListRecord {
-    }
-
-    static class ProductFormRecord extends FormRecord {
-    }
-
-    static class ProductListRecord extends ListRecord {
-    }
+    static class OrderFormRecord extends FormRecord {}
+    static class OrderListRecord extends ListRecord {}
+    static class ProductFormRecord extends FormRecord {}
+    static class ProductListRecord extends ListRecord {}
 
     @Test
     public void testIntermediateUnions() {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TestEnums.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TestEnums.java
@@ -68,11 +68,8 @@ public class TestEnums {
     }
 
     public enum JsonPropertyValuedEnum {
-        @JsonProperty("_A")
-        A,
-        @JsonProperty("_B")
-        B,
-        @JsonProperty("_C")
-        C
+        @JsonProperty("_A") A,
+        @JsonProperty("_B") B,
+        @JsonProperty("_C") C
     }
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TsTypeTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/TsTypeTest.java
@@ -5,9 +5,10 @@ import cz.habarta.typescript.generator.TsType.IndexedArrayType;
 import cz.habarta.typescript.generator.TsType.ObjectType;
 import cz.habarta.typescript.generator.TsType.UnionType;
 import cz.habarta.typescript.generator.compiler.Symbol;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.Test;
 
 import static cz.habarta.typescript.generator.TsType.Number;
 import static cz.habarta.typescript.generator.TsType.String;
@@ -15,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class TsTypeTest {
-
     @Test
     public void testEquals() {
         assertEquals(new TsType.ReferenceType(new Symbol(new String("Foo"))),

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/UtilsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/UtilsTest.java
@@ -2,18 +2,17 @@
 package cz.habarta.typescript.generator;
 
 import cz.habarta.typescript.generator.util.Utils;
-import java.io.File;
-import java.util.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class UtilsTest {
+import java.io.File;
+import java.util.*;
 
+public class UtilsTest {
     @Test
     public void testReplaceExtension() {
         Assertions.assertEquals(new File("test.dir/test.js"), Utils.replaceExtension(new File("test.dir/test"), ".js"));
-        Assertions.assertEquals(new File("test.dir/test.1.js"),
-                Utils.replaceExtension(new File("test.dir/test.1.ts"), ".js"));
+        Assertions.assertEquals(new File("test.dir/test.1.js"), Utils.replaceExtension(new File("test.dir/test.1.ts"), ".js"));
     }
 
     @Test
@@ -69,9 +68,7 @@ public class UtilsTest {
         Assertions.assertFalse(Utils.isPrimitiveType(Date.class));
         Assertions.assertFalse(Utils.isPrimitiveType(Collection.class));
         Assertions.assertFalse(Utils.isPrimitiveType(Map.class));
-        class NewClass {
-        }
+        class NewClass{}
         Assertions.assertFalse(Utils.isPrimitiveType(NewClass.class));
     }
-
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/compiler/ModelCompilerUtilsTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/compiler/ModelCompilerUtilsTest.java
@@ -1,12 +1,12 @@
 
 package cz.habarta.typescript.generator.compiler;
 
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class ModelCompilerUtilsTest {
+import java.util.stream.Collectors;
 
+public class ModelCompilerUtilsTest {
     @Test
     public void testSplitIdentifierIntoWords() {
         Assertions.assertEquals("Red", splitIdentifierIntoWords("Red"));

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/AxiosClientExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/AxiosClientExtensionTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class AxiosClientExtensionTest {
-
     @Test
     public void test() {
         final Settings settings = TestUtils.settings();
@@ -26,24 +25,13 @@ public class AxiosClientExtensionTest {
 
         Assertions.assertTrue(output.contains("class OrganizationsResourceClient<O>"), errorMessage);
         Assertions.assertTrue(output.contains("class PersonResourceClient<O>"), errorMessage);
-        Assertions.assertTrue(output.contains("type RestResponse<R> = Promise<Axios.GenericAxiosResponse<R>>"),
-                errorMessage);
+        Assertions.assertTrue(output.contains("type RestResponse<R> = Promise<Axios.GenericAxiosResponse<R>>"), errorMessage);
 
-        Assertions.assertTrue(output.contains("class AxiosHttpClient implements HttpClient<Axios.AxiosRequestConfig>"),
-                errorMessage);
-        Assertions.assertTrue(output.contains(
-                "request<R>(requestConfig: { method: string; url: string; queryParams?: any; data?: any; copyFn?: (data: R) => R; options?: Axios.AxiosRequestConfig; }): RestResponse<R>"),
-                errorMessage);
-        Assertions.assertTrue(output.contains(
-                "class AxiosOrganizationsResourceClient extends OrganizationsResourceClient<Axios.AxiosRequestConfig>"),
-                errorMessage);
-        Assertions.assertTrue(
-                output.contains(
-                        "class AxiosPersonResourceClient extends PersonResourceClient<Axios.AxiosRequestConfig>"),
-                errorMessage);
-        Assertions.assertTrue(
-                output.contains("constructor(baseURL: string, axiosInstance: Axios.AxiosInstance = axios.create())"),
-                errorMessage);
+        Assertions.assertTrue(output.contains("class AxiosHttpClient implements HttpClient<Axios.AxiosRequestConfig>"), errorMessage);
+        Assertions.assertTrue(output.contains("request<R>(requestConfig: { method: string; url: string; queryParams?: any; data?: any; copyFn?: (data: R) => R; options?: Axios.AxiosRequestConfig; }): RestResponse<R>"), errorMessage);
+        Assertions.assertTrue(output.contains("class AxiosOrganizationsResourceClient extends OrganizationsResourceClient<Axios.AxiosRequestConfig>"), errorMessage);
+        Assertions.assertTrue(output.contains("class AxiosPersonResourceClient extends PersonResourceClient<Axios.AxiosRequestConfig>"), errorMessage);
+        Assertions.assertTrue(output.contains("constructor(baseURL: string, axiosInstance: Axios.AxiosInstance = axios.create())"), errorMessage);
     }
 
     @Test
@@ -66,22 +54,12 @@ public class AxiosClientExtensionTest {
 
         Assertions.assertTrue(output.contains("class OrganizationsResourceClient<O>"), errorMessage);
         Assertions.assertTrue(output.contains("class PersonResourceClient<O>"), errorMessage);
-        Assertions.assertTrue(output.contains("type RestResponse<R> = Promise<Axios.GenericAxiosResponse<R>>"),
-                errorMessage);
+        Assertions.assertTrue(output.contains("type RestResponse<R> = Promise<Axios.GenericAxiosResponse<R>>"), errorMessage);
 
-        Assertions.assertTrue(output.contains("class AxiosHttpClient implements HttpClient<Axios.AxiosRequestConfig>"),
-                errorMessage);
-        Assertions.assertTrue(output.contains(
-                "request<R>(requestConfig: { method: string; url: string; queryParams?: any; data?: any; copyFn?: (data: R) => R; options?: Axios.AxiosRequestConfig; }): RestResponse<R>"),
-                errorMessage);
-        Assertions.assertTrue(output.contains(
-                "export class AxiosOrganizationsResourceClient extends cz.habarta.typescript.generator.JaxrsApplicationTest.OrganizationsResourceClient<Axios.AxiosRequestConfig>"),
-                errorMessage);
-        Assertions.assertTrue(output.contains(
-                "class AxiosPersonResourceClient extends cz.habarta.typescript.generator.JaxrsApplicationTest.PersonResourceClient<Axios.AxiosRequestConfig>"),
-                errorMessage);
-        Assertions.assertTrue(
-                output.contains("constructor(baseURL: string, axiosInstance: Axios.AxiosInstance = axios.create())"),
-                errorMessage);
+        Assertions.assertTrue(output.contains("class AxiosHttpClient implements HttpClient<Axios.AxiosRequestConfig>"), errorMessage);
+        Assertions.assertTrue(output.contains("request<R>(requestConfig: { method: string; url: string; queryParams?: any; data?: any; copyFn?: (data: R) => R; options?: Axios.AxiosRequestConfig; }): RestResponse<R>"), errorMessage);
+        Assertions.assertTrue(output.contains("export class AxiosOrganizationsResourceClient extends cz.habarta.typescript.generator.JaxrsApplicationTest.OrganizationsResourceClient<Axios.AxiosRequestConfig>"), errorMessage);
+        Assertions.assertTrue(output.contains("class AxiosPersonResourceClient extends cz.habarta.typescript.generator.JaxrsApplicationTest.PersonResourceClient<Axios.AxiosRequestConfig>"), errorMessage);
+        Assertions.assertTrue(output.contains("constructor(baseURL: string, axiosInstance: Axios.AxiosInstance = axios.create())"), errorMessage);
     }
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/PropertyPolymorphismExtensionTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/ext/PropertyPolymorphismExtensionTest.java
@@ -1,17 +1,17 @@
 package cz.habarta.typescript.generator.ext;
 
 import cz.habarta.typescript.generator.*;
+import org.junit.jupiter.api.Test;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PropertyPolymorphismExtensionTest {
-
     @Retention(RetentionPolicy.RUNTIME)
     private @interface Marker {
     }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/library/GuavaTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/library/GuavaTest.java
@@ -12,14 +12,14 @@ import com.google.common.net.HostAndPort;
 import com.google.common.net.InternetDomainName;
 import cz.habarta.typescript.generator.*;
 import cz.habarta.typescript.generator.util.Utils;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 @SuppressWarnings("unused")
 public class GuavaTest {
-
     @Test
     public void testGuavaInJackson() throws JsonProcessingException {
         final ObjectMapper objectMapper = Utils.getObjectMapper();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/library/JodaTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/library/JodaTest.java
@@ -6,14 +6,14 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import cz.habarta.typescript.generator.*;
 import cz.habarta.typescript.generator.util.Utils;
-import java.util.List;
-import java.util.Map;
 import org.joda.time.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class JodaTest {
+import java.util.List;
+import java.util.Map;
 
+public class JodaTest {
     @Test
     public void testDate_forJodaDateTime() {
         final Settings settings = TestUtils.settings();

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p1/A.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p1/A.java
@@ -2,7 +2,5 @@
 package cz.habarta.typescript.generator.p1;
 
 public class A {
-
     public String sa;
-
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p1/C.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p1/C.java
@@ -4,7 +4,5 @@ package cz.habarta.typescript.generator.p1;
 import cz.habarta.typescript.generator.p2.B;
 
 public class C extends B {
-
     public String sc;
-
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p2/B.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p2/B.java
@@ -4,7 +4,5 @@ package cz.habarta.typescript.generator.p2;
 import cz.habarta.typescript.generator.p1.A;
 
 public class B extends A {
-
     public String sb;
-
 }

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p2/D.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/p2/D.java
@@ -6,7 +6,6 @@ import cz.habarta.typescript.generator.p1.C;
 import cz.habarta.typescript.generator.p1.E;
 
 public class D {
-
     public A a;
     public B b;
     public C c;

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/Jackson2ParserPropertiesTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/Jackson2ParserPropertiesTest.java
@@ -7,15 +7,15 @@ import com.fasterxml.jackson.databind.BeanProperty;
 import cz.habarta.typescript.generator.Settings;
 import cz.habarta.typescript.generator.TestUtils;
 import cz.habarta.typescript.generator.TypeScriptGenerator;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class Jackson2ParserPropertiesTest {
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
-    @JsonPropertyOrder({ "password1", "id2" })
+public class Jackson2ParserPropertiesTest {
+    @JsonPropertyOrder({"password1", "id2"})
     public static class UserOrdered {
         public String name;
         public String id1;
@@ -34,86 +34,54 @@ public class Jackson2ParserPropertiesTest {
     }
 
     public static class UserIndexed {
-        @JsonProperty(index = 5)
-        public String name;
-        @JsonProperty(index = 4)
-        public String id1;
-        @JsonProperty(index = 3)
-        public String id2;
-        @JsonProperty(index = 2)
-        public String password1;
-        @JsonProperty(index = 1)
-        public String password2;
+        @JsonProperty(index = 5) public String name;
+        @JsonProperty(index = 4) public String id1;
+        @JsonProperty(index = 3) public String id2;
+        @JsonProperty(index = 2) public String password1;
+        @JsonProperty(index = 1) public String password2;
     }
 
     public static class User1 {
-        @JsonProperty(access = JsonProperty.Access.READ_WRITE)
-        public String name;
-        @JsonProperty(access = JsonProperty.Access.READ_WRITE)
-        public String id1;
-        @JsonProperty(access = JsonProperty.Access.READ_WRITE)
-        public String id2;
-        @JsonProperty(access = JsonProperty.Access.READ_WRITE)
-        public String password1;
-        @JsonProperty(access = JsonProperty.Access.READ_WRITE)
-        public String password2;
+        @JsonProperty(access = JsonProperty.Access.READ_WRITE) public String name;
+        @JsonProperty(access = JsonProperty.Access.READ_WRITE) public String id1;
+        @JsonProperty(access = JsonProperty.Access.READ_WRITE) public String id2;
+        @JsonProperty(access = JsonProperty.Access.READ_WRITE) public String password1;
+        @JsonProperty(access = JsonProperty.Access.READ_WRITE) public String password2;
     }
 
     public static class User2 {
-        @JsonProperty(access = JsonProperty.Access.READ_WRITE)
-        public String name;
-        @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-        public String id1;
-        @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-        public String id2;
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        public String password1;
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        public String password2;
+        @JsonProperty(access = JsonProperty.Access.READ_WRITE) public String name;
+        @JsonProperty(access = JsonProperty.Access.READ_ONLY)  public String id1;
+        @JsonProperty(access = JsonProperty.Access.READ_ONLY)  public String id2;
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) public String password1;
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) public String password2;
     }
 
     public static class User3 {
-        @JsonProperty(access = JsonProperty.Access.READ_WRITE)
-        public String name;
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        public String password1;
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        public String password2;
-        @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-        public String id1;
-        @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-        public String id2;
+        @JsonProperty(access = JsonProperty.Access.READ_WRITE) public String name;
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) public String password1;
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) public String password2;
+        @JsonProperty(access = JsonProperty.Access.READ_ONLY)  public String id1;
+        @JsonProperty(access = JsonProperty.Access.READ_ONLY)  public String id2;
     }
 
     public static class User4 {
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        public String password1;
-        @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-        public String id1;
-        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-        public String password2;
-        @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-        public String id2;
-        @JsonProperty(access = JsonProperty.Access.READ_WRITE)
-        public String name;
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) public String password1;
+        @JsonProperty(access = JsonProperty.Access.READ_ONLY)  public String id1;
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY) public String password2;
+        @JsonProperty(access = JsonProperty.Access.READ_ONLY)  public String id2;
+        @JsonProperty(access = JsonProperty.Access.READ_WRITE) public String name;
     }
 
     @Test
     public void testPropertyOrder() {
-        Assertions.assertEquals(Arrays.asList("password1", "id2", "name", "id1", "password2"),
-                getProperties(UserOrdered.class));
-        Assertions.assertEquals(Arrays.asList("id1", "id2", "name", "password1", "password2"),
-                getProperties(UserAlphabetic.class));
-        Assertions.assertEquals(Arrays.asList("password2", "password1", "id2", "id1", "name"),
-                getProperties(UserIndexed.class));
-        Assertions.assertEquals(Arrays.asList("name", "id1", "id2", "password1", "password2"),
-                getProperties(User1.class));
-        Assertions.assertEquals(Arrays.asList("name", "id1", "id2", "password1", "password2"),
-                getProperties(User2.class));
-        Assertions.assertEquals(Arrays.asList("name", "password1", "password2", "id1", "id2"),
-                getProperties(User3.class));
-        Assertions.assertEquals(Arrays.asList("password1", "id1", "password2", "id2", "name"),
-                getProperties(User4.class));
+        Assertions.assertEquals(Arrays.asList("password1", "id2", "name", "id1", "password2"), getProperties(UserOrdered.class));
+        Assertions.assertEquals(Arrays.asList("id1", "id2", "name", "password1", "password2"), getProperties(UserAlphabetic.class));
+        Assertions.assertEquals(Arrays.asList("password2", "password1", "id2", "id1", "name"), getProperties(UserIndexed.class));
+        Assertions.assertEquals(Arrays.asList("name", "id1", "id2", "password1", "password2"), getProperties(User1.class));
+        Assertions.assertEquals(Arrays.asList("name", "id1", "id2", "password1", "password2"), getProperties(User2.class));
+        Assertions.assertEquals(Arrays.asList("name", "password1", "password2", "id1", "id2"), getProperties(User3.class));
+        Assertions.assertEquals(Arrays.asList("password1", "id1", "password2", "id2", "name"), getProperties(User4.class));
     }
 
     private List<String> getProperties(Class<?> beanClass) {

--- a/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbV1ParserTest.java
+++ b/typescript-generator-core/src/test/java/cz/habarta/typescript/generator/parser/JsonbV1ParserTest.java
@@ -2,21 +2,21 @@ package cz.habarta.typescript.generator.parser;
 
 import cz.habarta.typescript.generator.*;
 import jakarta.json.*;
-import jakarta.json.bind.annotation.JsonbCreator;
-import jakarta.json.bind.annotation.JsonbProperty;
-import jakarta.json.bind.annotation.JsonbTransient;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.json.bind.annotation.JsonbCreator;
+import javax.json.bind.annotation.JsonbProperty;
+import javax.json.bind.annotation.JsonbTransient;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.*;
 
-public class JsonbParserTest {
+public class JsonbV1ParserTest {
     private Settings settings;
 
     @BeforeEach


### PR DESCRIPTION
# Fix #31

## Adds new tests to CustomTypeMappingTest

Confirm the issue of ignoring the generic type argument and mapping every type that matches the raw class name to the mapped type.

For instance, if we configure the plugin to map List<BigDecimal> to number[], it will map every List attribute to the target type. Even a List<String> will be mapped to number[] in this example.

## Settings

- Makes Settings.loadPrimitiveOrRegularClass protected to allow it to be tested
- Refactor SettingsTest ** Use Assertions static import to simplify code ** Add SettingsTest.testLoadPrimitiveOrRegularClass ** Changes SettingsTest.testLoadPrimitiveOrRegularClass to include class names that use nested generic types and check if the correct class/interface reference (type reference) is loaded.

## Stores an empty list by default in Settings.GenericName.typeParameters instead of null

- Storing null required always checking that to avoid NullPointerException, making the code dirty.
- Replacing the value by an empty list removes those checks and makes it easier to implement the fix for the current issue.

## Updates the regex in Settings.parseGenericName

That enables the correct parse of nested generic type arguments. If we have a type such as Class<T1<T2>, T3>, type arguments won't be parsed as T1 and T3 anymore, but as T1<T2> and T3.

The Class[T1[T2], T3] syntax also works.

## Fix the issue of custom type mapping not loading a class that has generic type arguments

The classLoader.loadClass() method requires the raw class name to find the class to load (that is the class name without the generic type arguments).

The Settings.loadPrimitiveOrRegularClass now removes the generic parameters from the class name to load the class correctly.

## Fix the issue in CustomMappingTypeProcessor that was mapping every type that matches the class raw name, ignoring the generic parameters

- If we had a mapping List<BigInteger>:number[], every kind of list was being mapped to number[], even List<String> and any other kind of list.
- Update the CustomMappingTypeProcessor.processType() to filter by the generic type arguments after checking the raw class name, to confirm the exact type (such as List<BigInteger> instead of just List) before mapping.
- The previous change in the default value of Settings.GenericName.typeParameters to an empty list makes the filter easier and NPE-safe.

## Update the ModelCompiler.isValidIdentifierPart() to include more valid chars

Since now the class CustomMappingTypeProcessor correctly extracts each generic type argument (even nested ones), a generic type can have some special chars. For instance, in a type such as java.util.List<java.util.List<String>>, the generic type argument is java.util.List<String>,
which has the characters:   .   <   >

Previously, the class was indicating this as an invalid identifier for the type. But this is a valid one, even for Java or TypeScript.

## Other changes

- Adds files generated during test execution to .gitignore
- Adds test in SettingsTest to confirm the issue of ignoring nested generic type arguments. Considering a class such as List<List<Double>>, the generic type argument is List<Double>, but it was being parsed as List.
- Adds toString(), equals() and hashCode() to Settings.GenericName inner class to make tests easier.
- Refactor GenericsResolverTest add Assertions static import to make test simpler.
- Add tests for the new GenericsResolver.typeParameterNameList but I don't know how to make the test work yet.
- Update Settings.loadPrimitiveOrRegularClass comment
- Update Settings.loadPrimitiveOrRegularClass to use positive condition. It doesn't change behavior.